### PR TITLE
Test descendant selector

### DIFF
--- a/cts.json
+++ b/cts.json
@@ -1573,6 +1573,64 @@
       "name": "union array slice, underflowing step",
       "selector": "$[-1:-10:-231584178474632390847141970017375815706539969331281128078915168015826259279872]",
       "invalid_selector": true
+    },
+    {
+      "name": "descendant selector, index",
+      "selector" : "$..[1]",
+      "document" : {"o": [0, 1, [2, 3]]},
+      "result": [
+        1,
+        3
+     ]
+    },
+    {
+      "name": "descendant selector, dot child",
+      "selector" : "$..a",
+      "document" : {"o": [{"a": "b"}, {"a":"c"}]},
+      "result": [
+        "b",
+        "c"
+     ]
+    },
+    {
+      "name": "descendant selector, wildcard, array",
+      "selector" : "$..*",
+      "document" : [0, 1],
+      "result": [
+        0,
+        1
+     ]
+    },
+    {
+      "name": "descendant selector, wildcard, object",
+      "selector" : "$..*",
+      "document" : {"a": "b"},
+      "result": [
+        "b"
+     ]
+    },
+    {
+      "name": "descendant selector, wildcard, nesting",
+      "selector" : "$..*",
+      "document" : {
+        "o": [{"a": "b"}]
+      },
+      "result": [
+        [
+           {
+              "a" : "b"
+           }
+        ],
+        {
+           "a" : "b"
+        },
+        "b"
+     ]
+    },
+    {
+      "name": "bald descendant selector",
+      "selector": "$..",
+      "invalid_selector": true
     }
   ]
 }

--- a/cts.json
+++ b/cts.json
@@ -84,6 +84,18 @@
       ]
     },
     {
+      "name": "wildcarded index of array",
+      "selector": "$[*]",
+      "document": [
+        "first",
+        "second"
+      ],
+      "result": [
+        "first",
+        "second"
+      ]
+    },
+    {
       "name": "wildcarded child dot child",
       "selector": "$.*.a",
       "document": {
@@ -1602,6 +1614,15 @@
      ]
     },
     {
+      "name": "descendant selector, index wildcard, array",
+      "selector" : "$..[*]",
+      "document" : [0, 1],
+      "result": [
+        0,
+        1
+     ]
+    },
+    {
       "name": "descendant selector, wildcard, object",
       "selector" : "$..*",
       "document" : {"a": "b"},
@@ -1625,6 +1646,17 @@
            "a" : "b"
         },
         "b"
+     ]
+    },
+    {
+      "name": "descendant selector, list",
+      "selector" : "$..['a', 'd']",
+      "document" : [{"a": "b", "d": "e"}, {"a":"c", "d": "f"}],
+      "result": [
+        "b",
+        "e",
+        "c",
+        "f"
      ]
     },
     {


### PR DESCRIPTION
Non-deterministic cases are deferred.

Fixes https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/issues/7


This PR assumes https://github.com/ietf-wg-jsonpath/draft-ietf-jsonpath-base/issues/215 will be resolved by https://github.com/ietf-wg-jsonpath/draft-ietf-jsonpath-base/pull/218. We should defer merging this PR until https://github.com/ietf-wg-jsonpath/draft-ietf-jsonpath-base/pull/218 lands.