### PR TITLE
Added cases for filter functions

### DIFF
--- a/cts.json
+++ b/cts.json
@@ -2139,6 +2139,16 @@
       "result": []
     },
     {
+      "name": "filter, length function, non-array/string arg",
+      "selector" : "$[?length(1)>=2]",
+      "invalid_selector": true
+    },
+    {
+      "name": "filter, length function, result must be compared",
+      "selector" : "$[?length(@.a)]",
+      "invalid_selector": true
+    },
+    {
       "name": "filter, count function",
       "selector" : "$[?count(@..*)>2]",
       "document" : [
@@ -2150,6 +2160,16 @@
         {"a": [1,2,3]},
         {"a": [1], "d":"f"}
       ]
+    },
+    {
+      "name": "filter, count function, non-array/string arg",
+      "selector" : "$[?count(1)>2]",
+      "invalid_selector": true
+    },
+    {
+      "name": "filter, count function, result must be compared",
+      "selector" : "$[?count(@..*)]",
+      "invalid_selector": true
     },
     {
       "name": "filter, match function, found match",
@@ -2177,6 +2197,21 @@
       "selector" : "$[?!match(@.a, '2022-01-[0-9]{2}')]",
       "document" : [{"a": "not a match"}],
       "result": [{"a": "not a match"}]
+    },
+    {
+      "name": "filter, match function, invalid first arg",
+      "selector" : "$[?match(1, '2022-01-[0-9]{2}')]",
+      "invalid_selector": true
+    },
+    {
+      "name": "filter, match function, invalid second arg",
+      "selector" : "$[?match(@.a, 1)]",
+      "invalid_selector": true
+    },
+    {
+      "name": "filter, match function, result cannot be compared",
+      "selector" : "$[?match(@.a, '2022-01-[0-9]{2}')==true]",
+      "invalid_selector": true
     },
     {
       "name": "filter, search function, at the end",
@@ -2219,6 +2254,21 @@
       "selector" : "$[?!search(@.a, '2022-01-[0-9]{2}')]",
       "document" : [{"a": "not a match"}],
       "result": [{"a": "not a match"}]
+    },
+    {
+      "name": "filter, search function, invalid first arg",
+      "selector" : "$[?search(1, '2022-01-[0-9]{2}')]",
+      "invalid_selector": true
+    },
+    {
+      "name": "filter, search function, invalid second arg",
+      "selector" : "$[?search(@.a, 1)]",
+      "invalid_selector": true
+    },
+    {
+      "name": "filter, search function, result cannot be compared",
+      "selector" : "$[?search(@.a, '2022-01-[0-9]{2}')==true]",
+      "invalid_selector": true
     }
   ]
 }

--- a/cts.json
+++ b/cts.json
@@ -2115,6 +2115,85 @@
       "result": [
         {"d": "f"}
       ]
+    },
+    {
+      "name": "filter, length function, string data",
+      "selector" : "$[?length(@.a)>=2]",
+      "document" : [{"a": "ab"}, {"a": "d"}],
+      "result": [
+        {"a": "ab"}
+      ]
+    },
+    {
+      "name": "filter, length function, array data",
+      "selector" : "$[?length(@.a)>=2]",
+      "document" : [{"a": [1,2,3]}, {"a": [1]}],
+      "result": [
+        {"a": [1,2,3]}
+      ]
+    },
+    {
+      "name": "filter, length function, missing data",
+      "selector" : "$[?length(@.a)>=2]",
+      "document" : [{"d": "f"}],
+      "result": []
+    },
+    {
+      "name": "filter, count function",
+      "selector" : "$[?count(@..*)>2]",
+      "document" : [
+        {"a": [1, 2, 3]},
+        {"a": [1], "d": "f"},
+        {"a": 1, "d": "f"}
+      ],
+      "result": [
+        {"a": [1,2,3]},
+        {"a": [1], "d":"f"}
+      ]
+    },
+    {
+      "name": "filter, match function, found match",
+      "selector" : "$[?match(@.a, '2022-01-[0-9]{2}')]",
+      "document" : [{"a": "2022-01-18"}],
+      "result": [
+        {"a":"2022-01-18"}
+      ]
+    },
+    {
+      "name": "filter, match function, not a match",
+      "selector" : "$[?match(@.a, '2022-01-[0-9]{2}')]",
+      "document" : [{"a": "not a match"}],
+      "result": []
+    },
+    {
+      "name": "filter, search function, at the end",
+      "selector" : "$[?search(@.a, '2022-01-[0-9]{2}')]",
+      "document" : [{"a": "at the end is 2022-01-84"}],
+      "result": [
+        {"a": "at the end is 2022-01-84"}
+      ]
+    },
+    {
+      "name": "filter, search function, at the start",
+      "selector" : "$[?search(@.a, '2022-01-[0-9]{2}')]",
+      "document" : [{"a": "2022-01-84 is at the start"}],
+      "result": [
+        {"a": "2022-01-84 is at the start"}
+      ]
+    },
+    {
+      "name": "filter, search function, in the middle",
+      "selector" : "$[?search(@.a, '2022-01-[0-9]{2}')]",
+      "document" : [{"a": "contains 2022-01-18 in the middle"}],
+      "result": [
+        {"a": "contains 2022-01-18 in the middle"}
+      ]
+    },
+    {
+      "name": "filter, search function, not a match",
+      "selector" : "$[?search(@.a, '2022-01-[0-9]{2}')]",
+      "document" : [{"a": "not a match"}],
+      "result": []
     }
   ]
 }

--- a/cts.json
+++ b/cts.json
@@ -2185,6 +2185,14 @@
       ]
     },
     {
+      "name": "filter, match function, double quotes",
+      "selector" : "$[?match(@.a, \"a.*\")]",
+      "document" : [{"a": "ab"}],
+      "result": [
+        {"a":"ab"}
+      ]
+    },
+    {
       "name": "filter, match function, don't select match",
       "selector" : "$[?!match(@.a, 'a.*')]",
       "document" : [{"a": "ab"}],
@@ -2221,6 +2229,14 @@
     {
       "name": "filter, search function, at the end",
       "selector" : "$[?search(@.a, 'a.*')]",
+      "document" : [{"a": "the end is ab"}],
+      "result": [
+        {"a": "the end is ab"}
+      ]
+    },
+    {
+      "name": "filter, search function, double quotes",
+      "selector" : "$[?search(@.a, \"a.*\")]",
       "document" : [{"a": "the end is ab"}],
       "result": [
         {"a": "the end is ab"}

--- a/cts.json
+++ b/cts.json
@@ -2155,6 +2155,16 @@
       "invalid_selector": true
     },
     {
+      "name": "filter, length function, no params",
+      "selector" : "$[?length()==1]",
+      "invalid_selector": true
+    },
+    {
+      "name": "filter, length function, too many params",
+      "selector" : "$[?length(@.a,@.b)==1]",
+      "invalid_selector": true
+    },
+    {
       "name": "filter, count function",
       "selector" : "$[?count(@..*)>2]",
       "document" : [
@@ -2180,6 +2190,16 @@
     {
       "name": "filter, count function, result must be compared",
       "selector" : "$[?count(@..*)]",
+      "invalid_selector": true
+    },
+    {
+      "name": "filter, count function, no params",
+      "selector" : "$[?count()==1]",
+      "invalid_selector": true
+    },
+    {
+      "name": "filter, count function, too many params",
+      "selector" : "$[?count(@.a,@.b)==1]",
       "invalid_selector": true
     },
     {
@@ -2232,6 +2252,16 @@
     {
       "name": "filter, match function, result cannot be compared",
       "selector" : "$[?match(@.a, 'a.*')==true]",
+      "invalid_selector": true
+    },
+    {
+      "name": "filter, match function, too few params",
+      "selector" : "$[?match(@.a)==1]",
+      "invalid_selector": true
+    },
+    {
+      "name": "filter, match function, too many params",
+      "selector" : "$[?match(@.a,@.b,@.c)==1]",
       "invalid_selector": true
     },
     {
@@ -2299,6 +2329,16 @@
     {
       "name": "filter, search function, result cannot be compared",
       "selector" : "$[?search(@.a, 'a.*')==true]",
+      "invalid_selector": true
+    },
+    {
+      "name": "filter, search function, too few params",
+      "selector" : "$[?search(@.a)==1]",
+      "invalid_selector": true
+    },
+    {
+      "name": "filter, search function, too many params",
+      "selector" : "$[?search(@.a,@.b,@.c)==1]",
       "invalid_selector": true
     }
   ]

--- a/cts.json
+++ b/cts.json
@@ -2146,8 +2146,7 @@
     {
       "name": "filter, length function, non-array/string arg",
       "selector" : "$[?length(1)>=2]",
-      "document" : [{"a": "ab"}, {"a": "d"}],
-      "result": []
+      "invalid_selector": true
     },
     {
       "name": "filter, length function, result must be compared",
@@ -2180,12 +2179,7 @@
     {
       "name": "filter, count function, non-array/string arg",
       "selector" : "$[?count(1)>2]",
-      "document" : [
-        {"a": [1, 2, 3]},
-        {"a": [1], "d": "f"},
-        {"a": 1, "d": "f"}
-      ],
-      "result": []
+      "invalid_selector": true
     },
     {
       "name": "filter, count function, result must be compared",
@@ -2240,14 +2234,12 @@
     {
       "name": "filter, match function, invalid first arg",
       "selector" : "$[?match(1, 'a.*')]",
-      "document" : [{"a": "ab"}],
-      "result": []
+      "invalid_selector": true
     },
     {
       "name": "filter, match function, invalid second arg",
       "selector" : "$[?match(@.a, 1)]",
-      "document" : [{"a": "ab"}],
-      "result": []
+      "invalid_selector": true
     },
     {
       "name": "filter, match function, result cannot be compared",
@@ -2317,14 +2309,12 @@
     {
       "name": "filter, search function, invalid first arg",
       "selector" : "$[?search(1, 'a.*')]",
-      "document" : [{"a": "ab"}],
-      "result": []
+      "invalid_selector": true
     },
     {
       "name": "filter, search function, invalid second arg",
       "selector" : "$[?search(@.a, 1)]",
-      "document" : [{"a": "ab"}],
-      "result": []
+      "invalid_selector": true
     },
     {
       "name": "filter, search function, result cannot be compared",
@@ -2333,12 +2323,12 @@
     },
     {
       "name": "filter, search function, too few params",
-      "selector" : "$[?search(@.a)==1]",
+      "selector" : "$[?search(@.a)]",
       "invalid_selector": true
     },
     {
       "name": "filter, search function, too many params",
-      "selector" : "$[?search(@.a,@.b,@.c)==1]",
+      "selector" : "$[?search(@.a,@.b,@.c)]",
       "invalid_selector": true
     }
   ]

--- a/cts.json
+++ b/cts.json
@@ -2146,7 +2146,8 @@
     {
       "name": "filter, length function, non-array/string arg",
       "selector" : "$[?length(1)>=2]",
-      "invalid_selector": true
+      "document" : [{"a": "ab"}, {"a": "d"}],
+      "result": []
     },
     {
       "name": "filter, length function, result must be compared",
@@ -2169,7 +2170,12 @@
     {
       "name": "filter, count function, non-array/string arg",
       "selector" : "$[?count(1)>2]",
-      "invalid_selector": true
+      "document" : [
+        {"a": [1, 2, 3]},
+        {"a": [1], "d": "f"},
+        {"a": 1, "d": "f"}
+      ],
+      "result": []
     },
     {
       "name": "filter, count function, result must be compared",
@@ -2214,12 +2220,14 @@
     {
       "name": "filter, match function, invalid first arg",
       "selector" : "$[?match(1, 'a.*')]",
-      "invalid_selector": true
+      "document" : [{"a": "ab"}],
+      "result": []
     },
     {
       "name": "filter, match function, invalid second arg",
       "selector" : "$[?match(@.a, 1)]",
-      "invalid_selector": true
+      "document" : [{"a": "ab"}],
+      "result": []
     },
     {
       "name": "filter, match function, result cannot be compared",
@@ -2279,12 +2287,14 @@
     {
       "name": "filter, search function, invalid first arg",
       "selector" : "$[?search(1, 'a.*')]",
-      "invalid_selector": true
+      "document" : [{"a": "ab"}],
+      "result": []
     },
     {
       "name": "filter, search function, invalid second arg",
       "selector" : "$[?search(@.a, 1)]",
-      "invalid_selector": true
+      "document" : [{"a": "ab"}],
+      "result": []
     },
     {
       "name": "filter, search function, result cannot be compared",

--- a/cts.json
+++ b/cts.json
@@ -961,6 +961,11 @@
       "invalid_selector": true
     },
     {
+      "name": "index selector, not actually an index, overflowing index leads into general text",
+      "selector": "$[231584178474632390847141970017375815706539969331281128078915168SomeRandomText]",
+      "invalid_selector": true
+    },
+    {
       "name": "index selector, negative",
       "selector": "$[-1]",
       "document": [
@@ -2173,34 +2178,34 @@
     },
     {
       "name": "filter, match function, found match",
-      "selector" : "$[?match(@.a, '2022-01-[0-9]{2}')]",
-      "document" : [{"a": "2022-01-18"}],
+      "selector" : "$[?match(@.a, 'a.*')]",
+      "document" : [{"a": "ab"}],
       "result": [
-        {"a":"2022-01-18"}
+        {"a":"ab"}
       ]
     },
     {
       "name": "filter, match function, don't select match",
-      "selector" : "$[?!match(@.a, '2022-01-[0-9]{2}')]",
-      "document" : [{"a": "2022-01-18"}],
+      "selector" : "$[?!match(@.a, 'a.*')]",
+      "document" : [{"a": "ab"}],
       "result": [
       ]
     },
     {
       "name": "filter, match function, not a match",
-      "selector" : "$[?match(@.a, '2022-01-[0-9]{2}')]",
-      "document" : [{"a": "not a match"}],
+      "selector" : "$[?match(@.a, 'a.*')]",
+      "document" : [{"a": "bc"}],
       "result": []
     },
     {
       "name": "filter, match function, select non-match",
-      "selector" : "$[?!match(@.a, '2022-01-[0-9]{2}')]",
-      "document" : [{"a": "not a match"}],
-      "result": [{"a": "not a match"}]
+      "selector" : "$[?!match(@.a, 'a.*')]",
+      "document" : [{"a": "bc"}],
+      "result": [{"a": "bc"}]
     },
     {
       "name": "filter, match function, invalid first arg",
-      "selector" : "$[?match(1, '2022-01-[0-9]{2}')]",
+      "selector" : "$[?match(1, 'a.*')]",
       "invalid_selector": true
     },
     {
@@ -2210,54 +2215,54 @@
     },
     {
       "name": "filter, match function, result cannot be compared",
-      "selector" : "$[?match(@.a, '2022-01-[0-9]{2}')==true]",
+      "selector" : "$[?match(@.a, 'a.*')==true]",
       "invalid_selector": true
     },
     {
       "name": "filter, search function, at the end",
-      "selector" : "$[?search(@.a, '2022-01-[0-9]{2}')]",
-      "document" : [{"a": "at the end is 2022-01-84"}],
+      "selector" : "$[?search(@.a, 'a.*')]",
+      "document" : [{"a": "the end is ab"}],
       "result": [
-        {"a": "at the end is 2022-01-84"}
+        {"a": "the end is ab"}
       ]
     },
     {
       "name": "filter, search function, at the start",
-      "selector" : "$[?search(@.a, '2022-01-[0-9]{2}')]",
-      "document" : [{"a": "2022-01-84 is at the start"}],
+      "selector" : "$[?search(@.a, 'a.*')]",
+      "document" : [{"a": "ab is at the start"}],
       "result": [
-        {"a": "2022-01-84 is at the start"}
+        {"a": "ab is at the start"}
       ]
     },
     {
       "name": "filter, search function, in the middle",
-      "selector" : "$[?search(@.a, '2022-01-[0-9]{2}')]",
-      "document" : [{"a": "contains 2022-01-18 in the middle"}],
+      "selector" : "$[?search(@.a, 'a.*')]",
+      "document" : [{"a": "contains two matches"}],
       "result": [
-        {"a": "contains 2022-01-18 in the middle"}
+        {"a": "contains two matches"}
       ]
     },
     {
       "name": "filter, search function, don't select match",
-      "selector" : "$[?!search(@.a, '2022-01-[0-9]{2}')]",
-      "document" : [{"a": "contains 2022-01-18 in the middle"}],
+      "selector" : "$[?!search(@.a, 'a.*')]",
+      "document" : [{"a": "contains two matches"}],
       "result": []
     },
     {
       "name": "filter, search function, not a match",
-      "selector" : "$[?search(@.a, '2022-01-[0-9]{2}')]",
-      "document" : [{"a": "not a match"}],
+      "selector" : "$[?search(@.a, 'a.*')]",
+      "document" : [{"a": "bc"}],
       "result": []
     },
     {
       "name": "filter, search function, select non-match",
-      "selector" : "$[?!search(@.a, '2022-01-[0-9]{2}')]",
-      "document" : [{"a": "not a match"}],
-      "result": [{"a": "not a match"}]
+      "selector" : "$[?!search(@.a, 'a.*')]",
+      "document" : [{"a": "bc"}],
+      "result": [{"a": "bc"}]
     },
     {
       "name": "filter, search function, invalid first arg",
-      "selector" : "$[?search(1, '2022-01-[0-9]{2}')]",
+      "selector" : "$[?search(1, 'a.*')]",
       "invalid_selector": true
     },
     {
@@ -2267,7 +2272,7 @@
     },
     {
       "name": "filter, search function, result cannot be compared",
-      "selector" : "$[?search(@.a, '2022-01-[0-9]{2}')==true]",
+      "selector" : "$[?search(@.a, 'a.*')==true]",
       "invalid_selector": true
     }
   ]

--- a/cts.json
+++ b/cts.json
@@ -2160,10 +2160,23 @@
       ]
     },
     {
+      "name": "filter, match function, don't select match",
+      "selector" : "$[?!match(@.a, '2022-01-[0-9]{2}')]",
+      "document" : [{"a": "2022-01-18"}],
+      "result": [
+      ]
+    },
+    {
       "name": "filter, match function, not a match",
       "selector" : "$[?match(@.a, '2022-01-[0-9]{2}')]",
       "document" : [{"a": "not a match"}],
       "result": []
+    },
+    {
+      "name": "filter, match function, select non-match",
+      "selector" : "$[?!match(@.a, '2022-01-[0-9]{2}')]",
+      "document" : [{"a": "not a match"}],
+      "result": [{"a": "not a match"}]
     },
     {
       "name": "filter, search function, at the end",
@@ -2190,10 +2203,22 @@
       ]
     },
     {
+      "name": "filter, search function, don't select match",
+      "selector" : "$[?!search(@.a, '2022-01-[0-9]{2}')]",
+      "document" : [{"a": "contains 2022-01-18 in the middle"}],
+      "result": []
+    },
+    {
       "name": "filter, search function, not a match",
       "selector" : "$[?search(@.a, '2022-01-[0-9]{2}')]",
       "document" : [{"a": "not a match"}],
       "result": []
+    },
+    {
+      "name": "filter, search function, select non-match",
+      "selector" : "$[?!search(@.a, '2022-01-[0-9]{2}')]",
+      "document" : [{"a": "not a match"}],
+      "result": [{"a": "not a match"}]
     }
   ]
 }


### PR DESCRIPTION
I think this should round out the current syntax for expressions

Resolves #8 
Relates to spec repo issues [#360](https://github.com/ietf-wg-jsonpath/draft-ietf-jsonpath-base/issues/360), [#361](https://github.com/ietf-wg-jsonpath/draft-ietf-jsonpath-base/issues/361), [#362](https://github.com/ietf-wg-jsonpath/draft-ietf-jsonpath-base/issues/362), [#367](https://github.com/ietf-wg-jsonpath/draft-ietf-jsonpath-base/issues/367), and [#368](https://github.com/ietf-wg-jsonpath/draft-ietf-jsonpath-base/issues/368).  Most of these have been created as a result of this PR.