### PR TITLE
Allow underscores in member name shorthand

### DIFF
--- a/cts.json
+++ b/cts.json
@@ -47,6 +47,17 @@
       ]
     },
     {
+      "name": "name shorthand, underscore",
+      "selector": "$._",
+      "document": {
+        "_": "A",
+        "_foo": "B"
+      },
+      "result": [
+        "A"
+      ]
+    },
+    {
       "name": "name shorthand, symbol",
       "selector": "$.&",
       "invalid_selector": true
@@ -54,16 +65,6 @@
     {
       "name": "name shorthand, number",
       "selector": "$.1",
-      "invalid_selector": true
-    },
-    {
-      "name": "name shorthand, underscore",
-      "selector": "$._",
-      "invalid_selector": true
-    },
-    {
-      "name": "name shorthand, underscore start",
-      "selector": "$._a",
       "invalid_selector": true
     },
     {


### PR DESCRIPTION
Please correct me if I'm wrong, but the standard seems to allow the name shorthands to start from (and consist of) an underscore.

https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/draft-ietf-jsonpath-base.html#name-syntax-8

```ABNF
child-segment             = bracketed-selection /
                            ("."
                             (wildcard-selector /
                              member-name-shorthand))

bracketed-selection       = "[" S selector *(S "," S selector) S "]"

member-name-shorthand     = name-first *name-char
name-first                = ALPHA /
                            "_"   /            ; _
                            %x80-10FFFF
                              ; any non-ASCII Unicode character
name-char                 = DIGIT / name-first

DIGIT                     =  %x30-39              ; 0-9
ALPHA                     =  %x41-5A / %x61-7A    ; A-Z / a-z
```