### PR TITLE
Add an edge case test that `.` matches \\u2029 and \\u2028

### DIFF
--- a/cts.json
+++ b/cts.json
@@ -3455,6 +3455,36 @@
       ]
     },
     {
+      "name": "functions, match, dot matcher on \\u2028",
+      "selector": "$[?match(@, '.')]",
+      "document": [
+        " ",
+        "\r",
+        "\n",
+        true,
+        [],
+        {}
+      ],
+      "result": [
+        " "
+      ]
+    },
+    {
+      "name": "functions, match, dot matcher on \\u2029",
+      "selector": "$[?match(@, '.')]",
+      "document": [
+        " ",
+        "\r",
+        "\n",
+        true,
+        [],
+        {}
+      ],
+      "result": [
+        " "
+      ]
+    },
+    {
       "name": "functions, match, result cannot be compared",
       "selector": "$[?match(@.a, 'a.*')==true]",
       "invalid_selector": true
@@ -3648,6 +3678,40 @@
       ],
       "result": [
         "a𐄁bc"
+      ]
+    },
+    {
+      "name": "functions, search, dot matcher on \\u2028",
+      "selector": "$[?search(@, '.')]",
+      "document": [
+        " ",
+        "\r \n",
+        "\r",
+        "\n",
+        true,
+        [],
+        {}
+      ],
+      "result": [
+        " ",
+        "\r \n"
+      ]
+    },
+    {
+      "name": "functions, search, dot matcher on \\u2029",
+      "selector": "$[?search(@, '.')]",
+      "document": [
+        " ",
+        "\r \n",
+        "\r",
+        "\n",
+        true,
+        [],
+        {}
+      ],
+      "result": [
+        " ",
+        "\r \n"
       ]
     },
     {

--- a/tests/functions/match.json
+++ b/tests/functions/match.json
@@ -72,6 +72,18 @@
       "result": ["a\uD800\uDD01b"]
     },
     {
+      "name": "dot matcher on \\u2028",
+      "selector": "$[?match(@, '.')]",
+      "document": ["\u2028", "\r", "\n", true, [], {}],
+      "result": ["\u2028"]
+    },
+    {
+      "name": "dot matcher on \\u2029",
+      "selector": "$[?match(@, '.')]",
+      "document": ["\u2029", "\r", "\n", true, [], {}],
+      "result": ["\u2029"]
+    },
+    {
       "name": "result cannot be compared",
       "selector" : "$[?match(@.a, 'a.*')==true]",
       "invalid_selector": true

--- a/tests/functions/search.json
+++ b/tests/functions/search.json
@@ -87,6 +87,18 @@
       "result": ["a\uD800\uDD01bc"]
     },
     {
+      "name": "dot matcher on \\u2028",
+      "selector": "$[?search(@, '.')]",
+      "document": ["\u2028", "\r\u2028\n", "\r", "\n", true, [], {}],
+      "result": ["\u2028", "\r\u2028\n"]
+    },
+    {
+      "name": "dot matcher on \\u2029",
+      "selector": "$[?search(@, '.')]",
+      "document": ["\u2029", "\r\u2029\n", "\r", "\n", true, [], {}],
+      "result": ["\u2029", "\r\u2029\n"]
+    },
+    {
       "name": "result cannot be compared",
       "selector" : "$[?search(@.a, 'a.*')==true]",
       "invalid_selector": true


### PR DESCRIPTION
I-Regexp follows the [XSD-2](https://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#regexs) which states that the equivalent character class for `.` is `[^\r\n]`. Some programming languages (e.g. Javascript, Dart) treat `.` differently, in particular it won't match Unicode chars `\u2029` and `\u2028`. This PR introduces a corresponding edge case test.