### PR TITLE
whitespace tests and some others

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,2 @@
+$localDir=$PSScriptRoot
+node build.js "$localDir/tests" > "$localDir/cts.json"

--- a/build.ps1
+++ b/build.ps1
@@ -1,2 +1,4 @@
+chcp 65001
+
 $localDir=$PSScriptRoot
 node build.js "$localDir/tests" > "$localDir/cts.json"

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 set -e
-path=$(dirname "$0")
-node build.js "$path/tests" > "$path/cts.json"
+localDir=$(dirname "$0")
+node build.js "$localDir/tests" > "$localDir/cts.json"

--- a/cts.json
+++ b/cts.json
@@ -160,24 +160,9 @@
       ]
     },
     {
-      "name": "basic, multiple selectors with whitespace",
-      "selector": "$[ 0 , 1 ]",
-      "document": [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9
-      ],
-      "result": [
-        0,
-        1
-      ]
+      "name": "basic, multiple selectors, space instead of comma",
+      "selector": "$[0 2]",
+      "invalid_selector": true
     },
     {
       "name": "basic, multiple selectors, name and index, array data",
@@ -351,7 +336,7 @@
     },
     {
       "name": "basic, descendant segment, multiple selectors",
-      "selector": "$..['a', 'd']",
+      "selector": "$..['a','d']",
       "document": [
         {
           "a": "b",
@@ -3186,8 +3171,87 @@
       ]
     },
     {
-      "name": "functions, count, non-array/string arg",
+      "name": "functions, count, single-node arg",
+      "selector": "$[?count(@.a)>1]",
+      "document": [
+        {
+          "a": [
+            1,
+            2,
+            3
+          ]
+        },
+        {
+          "a": [
+            1
+          ],
+          "d": "f"
+        },
+        {
+          "a": 1,
+          "d": "f"
+        }
+      ],
+      "result": []
+    },
+    {
+      "name": "functions, count, multiple-selector arg",
+      "selector": "$[?count(@['a','d'])>1]",
+      "document": [
+        {
+          "a": [
+            1,
+            2,
+            3
+          ]
+        },
+        {
+          "a": [
+            1
+          ],
+          "d": "f"
+        },
+        {
+          "a": 1,
+          "d": "f"
+        }
+      ],
+      "result": [
+        {
+          "a": [
+            1
+          ],
+          "d": "f"
+        },
+        {
+          "a": 1,
+          "d": "f"
+        }
+      ]
+    },
+    {
+      "name": "functions, count, non-query arg, number",
       "selector": "$[?count(1)>2]",
+      "invalid_selector": true
+    },
+    {
+      "name": "functions, count, non-query arg, string",
+      "selector": "$[?count('string')>2]",
+      "invalid_selector": true
+    },
+    {
+      "name": "functions, count, non-query arg, true",
+      "selector": "$[?count(true)>2]",
+      "invalid_selector": true
+    },
+    {
+      "name": "functions, count, non-query arg, false",
+      "selector": "$[?count(false)>2]",
+      "invalid_selector": true
+    },
+    {
+      "name": "functions, count, non-query arg, null",
+      "selector": "$[?count(null)>2]",
       "invalid_selector": true
     },
     {
@@ -3280,8 +3344,38 @@
       "result": []
     },
     {
-      "name": "functions, length, non-array/string arg",
+      "name": "functions, length, number arg",
       "selector": "$[?length(1)>=2]",
+      "document": [
+        {
+          "d": "f"
+        }
+      ],
+      "result": []
+    },
+    {
+      "name": "functions, length, true arg",
+      "selector": "$[?length(true)>=2]",
+      "document": [
+        {
+          "d": "f"
+        }
+      ],
+      "result": []
+    },
+    {
+      "name": "functions, length, false arg",
+      "selector": "$[?length(false)>=2]",
+      "document": [
+        {
+          "d": "f"
+        }
+      ],
+      "result": []
+    },
+    {
+      "name": "functions, length, null arg",
+      "selector": "$[?length(null)>=2]",
       "document": [
         {
           "d": "f"
@@ -3721,6 +3815,2286 @@
       "name": "functions, value, result must be compared",
       "selector": "$[?value(@.a)]",
       "invalid_selector": true
+    },
+    {
+      "name": "whitespace, functions, space between function name and parenthesis",
+      "selector": "$[?count (@.*)==1]",
+      "invalid_selector": true
+    },
+    {
+      "name": "whitespace, functions, newline between function name and parenthesis",
+      "selector": "$[?count\n(@.*)==1]",
+      "invalid_selector": true
+    },
+    {
+      "name": "whitespace, functions, tab between function name and parenthesis",
+      "selector": "$[?count\t(@.*)==1]",
+      "invalid_selector": true
+    },
+    {
+      "name": "whitespace, functions, return between function name and parenthesis",
+      "selector": "$[?count\r(@.*)==1]",
+      "invalid_selector": true
+    },
+    {
+      "name": "whitespace, functions, space between parenthesis and arg",
+      "selector": "$[?count( @.*)==1]",
+      "document": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "a": 2,
+          "b": 1
+        }
+      ],
+      "result": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, functions, newline between parenthesis and arg",
+      "selector": "$[?count(\n@.*)==1]",
+      "document": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "a": 2,
+          "b": 1
+        }
+      ],
+      "result": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, functions, tab between parenthesis and arg",
+      "selector": "$[?count(\t@.*)==1]",
+      "document": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "a": 2,
+          "b": 1
+        }
+      ],
+      "result": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, functions, return between parenthesis and arg",
+      "selector": "$[?count(\r@.*)==1]",
+      "document": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "a": 2,
+          "b": 1
+        }
+      ],
+      "result": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, functions, space between arg and comma",
+      "selector": "$[?search(@ ,'[a-z]+')]",
+      "document": [
+        "foo",
+        "123"
+      ],
+      "result": [
+        "foo"
+      ]
+    },
+    {
+      "name": "whitespace, functions, newline between arg and comma",
+      "selector": "$[?search(@\n,'[a-z]+')]",
+      "document": [
+        "foo",
+        "123"
+      ],
+      "result": [
+        "foo"
+      ]
+    },
+    {
+      "name": "whitespace, functions, tab between arg and comma",
+      "selector": "$[?search(@\t,'[a-z]+')]",
+      "document": [
+        "foo",
+        "123"
+      ],
+      "result": [
+        "foo"
+      ]
+    },
+    {
+      "name": "whitespace, functions, return between arg and comma",
+      "selector": "$[?search(@\r,'[a-z]+')]",
+      "document": [
+        "foo",
+        "123"
+      ],
+      "result": [
+        "foo"
+      ]
+    },
+    {
+      "name": "whitespace, functions, space between comma and arg",
+      "selector": "$[?search(@, '[a-z]+')]",
+      "document": [
+        "foo",
+        "123"
+      ],
+      "result": [
+        "foo"
+      ]
+    },
+    {
+      "name": "whitespace, functions, newline between comma and arg",
+      "selector": "$[?search(@,\n'[a-z]+')]",
+      "document": [
+        "foo",
+        "123"
+      ],
+      "result": [
+        "foo"
+      ]
+    },
+    {
+      "name": "whitespace, functions, tab between comma and arg",
+      "selector": "$[?search(@,\t'[a-z]+')]",
+      "document": [
+        "foo",
+        "123"
+      ],
+      "result": [
+        "foo"
+      ]
+    },
+    {
+      "name": "whitespace, functions, return between comma and arg",
+      "selector": "$[?search(@,\r'[a-z]+')]",
+      "document": [
+        "foo",
+        "123"
+      ],
+      "result": [
+        "foo"
+      ]
+    },
+    {
+      "name": "whitespace, functions, space between arg and parenthesis",
+      "selector": "$[?count(@.* )==1]",
+      "document": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "a": 2,
+          "b": 1
+        }
+      ],
+      "result": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, functions, newline between arg and parenthesis",
+      "selector": "$[?count(@.*\n)==1]",
+      "document": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "a": 2,
+          "b": 1
+        }
+      ],
+      "result": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, functions, tab between arg and parenthesis",
+      "selector": "$[?count(@.*\t)==1]",
+      "document": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "a": 2,
+          "b": 1
+        }
+      ],
+      "result": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, functions, return between arg and parenthesis",
+      "selector": "$[?count(@.*\r)==1]",
+      "document": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "a": 2,
+          "b": 1
+        }
+      ],
+      "result": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, space before ||",
+      "selector": "$[?@.a ||@.b]",
+      "document": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "c": 3
+        }
+      ],
+      "result": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, newline before ||",
+      "selector": "$[?@.a\n||@.b]",
+      "document": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "c": 3
+        }
+      ],
+      "result": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, tab before ||",
+      "selector": "$[?@.a\t||@.b]",
+      "document": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "c": 3
+        }
+      ],
+      "result": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, return before ||",
+      "selector": "$[?@.a\r||@.b]",
+      "document": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "c": 3
+        }
+      ],
+      "result": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, space after ||",
+      "selector": "$[?@.a|| @.b]",
+      "document": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "c": 3
+        }
+      ],
+      "result": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, newline after ||",
+      "selector": "$[?@.a||\n@.b]",
+      "document": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "c": 3
+        }
+      ],
+      "result": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, tab after ||",
+      "selector": "$[?@.a||\t@.b]",
+      "document": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "c": 3
+        }
+      ],
+      "result": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, return after ||",
+      "selector": "$[?@.a||\r@.b]",
+      "document": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "c": 3
+        }
+      ],
+      "result": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, space before &&",
+      "selector": "$[?@.a &&@.b]",
+      "document": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, newline before &&",
+      "selector": "$[?@.a\n&&@.b]",
+      "document": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, tab before &&",
+      "selector": "$[?@.a\t&&@.b]",
+      "document": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, return before &&",
+      "selector": "$[?@.a\r&&@.b]",
+      "document": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, space after &&",
+      "selector": "$[?@.a&& @.b]",
+      "document": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, newline after &&",
+      "selector": "$[?@.a&& @.b]",
+      "document": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, tab after &&",
+      "selector": "$[?@.a&& @.b]",
+      "document": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, return after &&",
+      "selector": "$[?@.a&& @.b]",
+      "document": [
+        {
+          "a": 1
+        },
+        {
+          "b": 2
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, space before ==",
+      "selector": "$[?@.a ==@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 1
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, newline before ==",
+      "selector": "$[?@.a\n==@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 1
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, tab before ==",
+      "selector": "$[?@.a\t==@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 1
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, return before ==",
+      "selector": "$[?@.a\r==@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 1
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, space after ==",
+      "selector": "$[?@.a== @.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 1
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, newline after ==",
+      "selector": "$[?@.a==\n@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 1
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, tab after ==",
+      "selector": "$[?@.a==\t@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 1
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, return after ==",
+      "selector": "$[?@.a==\r@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 1
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, space before !=",
+      "selector": "$[?@.a !=@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, newline before !=",
+      "selector": "$[?@.a\n!=@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, tab before !=",
+      "selector": "$[?@.a\t!=@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, return before !=",
+      "selector": "$[?@.a\r!=@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, space after !=",
+      "selector": "$[?@.a!= @.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, newline after !=",
+      "selector": "$[?@.a!=\n@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, tab after !=",
+      "selector": "$[?@.a!=\t@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, return after !=",
+      "selector": "$[?@.a!=\r@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, space before <",
+      "selector": "$[?@.a <@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, newline before <",
+      "selector": "$[?@.a\n<@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, tab before <",
+      "selector": "$[?@.a\t<@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, return before <",
+      "selector": "$[?@.a\r<@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, space after <",
+      "selector": "$[?@.a< @.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, newline after <",
+      "selector": "$[?@.a<\n@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, tab after <",
+      "selector": "$[?@.a<\t@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, return after <",
+      "selector": "$[?@.a<\r@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, space before >",
+      "selector": "$[?@.b >@.a]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, newline before >",
+      "selector": "$[?@.b\n>@.a]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, tab before >",
+      "selector": "$[?@.b\t>@.a]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, return before >",
+      "selector": "$[?@.b\r>@.a]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, space after >",
+      "selector": "$[?@.b> @.a]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, newline after >",
+      "selector": "$[?@.b>\n@.a]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, tab after >",
+      "selector": "$[?@.b>\t@.a]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, return after >",
+      "selector": "$[?@.b>\r@.a]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, space before <=",
+      "selector": "$[?@.a <=@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        },
+        {
+          "a": 2,
+          "b": 1
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, newline before <=",
+      "selector": "$[?@.a\n<=@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        },
+        {
+          "a": 2,
+          "b": 1
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, tab before <=",
+      "selector": "$[?@.a\t<=@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        },
+        {
+          "a": 2,
+          "b": 1
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, return before <=",
+      "selector": "$[?@.a\r<=@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        },
+        {
+          "a": 2,
+          "b": 1
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, space after <=",
+      "selector": "$[?@.a<= @.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        },
+        {
+          "a": 2,
+          "b": 1
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, newline after <=",
+      "selector": "$[?@.a<=\n@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        },
+        {
+          "a": 2,
+          "b": 1
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, tab after <=",
+      "selector": "$[?@.a<=\t@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        },
+        {
+          "a": 2,
+          "b": 1
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, return after <=",
+      "selector": "$[?@.a<=\r@.b]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        },
+        {
+          "a": 2,
+          "b": 1
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, space before >=",
+      "selector": "$[?@.b >=@.a]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        },
+        {
+          "a": 2,
+          "b": 1
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, newline before >=",
+      "selector": "$[?@.b\n>=@.a]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        },
+        {
+          "a": 2,
+          "b": 1
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, tab before >=",
+      "selector": "$[?@.b\t>=@.a]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        },
+        {
+          "a": 2,
+          "b": 1
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, return before >=",
+      "selector": "$[?@.b\r>=@.a]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        },
+        {
+          "a": 2,
+          "b": 1
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, space after >=",
+      "selector": "$[?@.b>= @.a]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        },
+        {
+          "a": 2,
+          "b": 1
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, newline after >=",
+      "selector": "$[?@.b>=\n@.a]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        },
+        {
+          "a": 2,
+          "b": 1
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, tab after >=",
+      "selector": "$[?@.b>=\t@.a]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        },
+        {
+          "a": 2,
+          "b": 1
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, return after >=",
+      "selector": "$[?@.b>=\r@.a]",
+      "document": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        },
+        {
+          "a": 2,
+          "b": 1
+        }
+      ],
+      "result": [
+        {
+          "a": 1,
+          "b": 1
+        },
+        {
+          "a": 1,
+          "b": 2
+        }
+      ]
+    },
+    {
+      "name": "whitespace, selectors, space between root and bracket",
+      "selector": "$ ['a']",
+      "invalid_selector": true
+    },
+    {
+      "name": "whitespace, selectors, newline between root and bracket",
+      "selector": "$\n['a']",
+      "invalid_selector": true
+    },
+    {
+      "name": "whitespace, selectors, tab between root and bracket",
+      "selector": "$\t['a']",
+      "invalid_selector": true
+    },
+    {
+      "name": "whitespace, selectors, return between root and bracket",
+      "selector": "$\r['a']",
+      "invalid_selector": true
+    },
+    {
+      "name": "whitespace, selectors, space between bracket and bracket",
+      "selector": "$['a'] ['b']",
+      "invalid_selector": true
+    },
+    {
+      "name": "whitespace, selectors, newline between root and bracket",
+      "selector": "$['a'] \n['b']",
+      "invalid_selector": true
+    },
+    {
+      "name": "whitespace, selectors, tab between root and bracket",
+      "selector": "$['a'] \t['b']",
+      "invalid_selector": true
+    },
+    {
+      "name": "whitespace, selectors, return between root and bracket",
+      "selector": "$['a'] \r['b']",
+      "invalid_selector": true
+    },
+    {
+      "name": "whitespace, selectors, space between root and dot",
+      "selector": "$ .a",
+      "invalid_selector": true
+    },
+    {
+      "name": "whitespace, selectors, newline between root and dot",
+      "selector": "$\n.a",
+      "invalid_selector": true
+    },
+    {
+      "name": "whitespace, selectors, tab between root and dot",
+      "selector": "$\t.a",
+      "invalid_selector": true
+    },
+    {
+      "name": "whitespace, selectors, return between root and dot",
+      "selector": "$\r.a",
+      "invalid_selector": true
+    },
+    {
+      "name": "whitespace, selectors, space between dot and name",
+      "selector": "$. a",
+      "invalid_selector": true
+    },
+    {
+      "name": "whitespace, selectors, newline between dot and name",
+      "selector": "$.\na",
+      "invalid_selector": true
+    },
+    {
+      "name": "whitespace, selectors, tab between dot and name",
+      "selector": "$.\ta",
+      "invalid_selector": true
+    },
+    {
+      "name": "whitespace, selectors, return between dot and name",
+      "selector": "$.\ra",
+      "invalid_selector": true
+    },
+    {
+      "name": "whitespace, selectors, space between recursive descent and name",
+      "selector": "$.. a",
+      "invalid_selector": true
+    },
+    {
+      "name": "whitespace, selectors, newline between recursive descent and name",
+      "selector": "$..\na",
+      "invalid_selector": true
+    },
+    {
+      "name": "whitespace, selectors, tab between recursive descent and name",
+      "selector": "$..\ta",
+      "invalid_selector": true
+    },
+    {
+      "name": "whitespace, selectors, return between recursive descent and name",
+      "selector": "$..\ra",
+      "invalid_selector": true
+    },
+    {
+      "name": "whitespace, selectors, space between bracket and selector",
+      "selector": "$[ 'a']",
+      "document": {
+        "a": "ab"
+      },
+      "result": [
+        "ab"
+      ]
+    },
+    {
+      "name": "whitespace, selectors, newline between bracket and selector",
+      "selector": "$[\n'a']",
+      "document": {
+        "a": "ab"
+      },
+      "result": [
+        "ab"
+      ]
+    },
+    {
+      "name": "whitespace, selectors, tab between bracket and selector",
+      "selector": "$[\t'a']",
+      "document": {
+        "a": "ab"
+      },
+      "result": [
+        "ab"
+      ]
+    },
+    {
+      "name": "whitespace, selectors, return between bracket and selector",
+      "selector": "$[\r'a']",
+      "document": {
+        "a": "ab"
+      },
+      "result": [
+        "ab"
+      ]
+    },
+    {
+      "name": "whitespace, selectors, space between selector and bracket",
+      "selector": "$['a' ]",
+      "document": {
+        "a": "ab"
+      },
+      "result": [
+        "ab"
+      ]
+    },
+    {
+      "name": "whitespace, selectors, newline between selector and bracket",
+      "selector": "$['a'\n]",
+      "document": {
+        "a": "ab"
+      },
+      "result": [
+        "ab"
+      ]
+    },
+    {
+      "name": "whitespace, selectors, tab between selector and bracket",
+      "selector": "$['a'\t]",
+      "document": {
+        "a": "ab"
+      },
+      "result": [
+        "ab"
+      ]
+    },
+    {
+      "name": "whitespace, selectors, return between selector and bracket",
+      "selector": "$['a'\r]",
+      "document": {
+        "a": "ab"
+      },
+      "result": [
+        "ab"
+      ]
+    },
+    {
+      "name": "whitespace, selectors, space between selector and comma",
+      "selector": "$['a' ,'b']",
+      "document": {
+        "a": "ab",
+        "b": "bc"
+      },
+      "result": [
+        "ab",
+        "bc"
+      ]
+    },
+    {
+      "name": "whitespace, selectors, newline between selector and comma",
+      "selector": "$['a'\n,'b']",
+      "document": {
+        "a": "ab",
+        "b": "bc"
+      },
+      "result": [
+        "ab",
+        "bc"
+      ]
+    },
+    {
+      "name": "whitespace, selectors, tab between selector and comma",
+      "selector": "$['a'\t,'b']",
+      "document": {
+        "a": "ab",
+        "b": "bc"
+      },
+      "result": [
+        "ab",
+        "bc"
+      ]
+    },
+    {
+      "name": "whitespace, selectors, return between selector and comma",
+      "selector": "$['a'\r,'b']",
+      "document": {
+        "a": "ab",
+        "b": "bc"
+      },
+      "result": [
+        "ab",
+        "bc"
+      ]
+    },
+    {
+      "name": "whitespace, selectors, space between comma and selector",
+      "selector": "$['a', 'b']",
+      "document": {
+        "a": "ab",
+        "b": "bc"
+      },
+      "result": [
+        "ab",
+        "bc"
+      ]
+    },
+    {
+      "name": "whitespace, selectors, newline between comma and selector",
+      "selector": "$['a',\n'b']",
+      "document": {
+        "a": "ab",
+        "b": "bc"
+      },
+      "result": [
+        "ab",
+        "bc"
+      ]
+    },
+    {
+      "name": "whitespace, selectors, tab between comma and selector",
+      "selector": "$['a',\t'b']",
+      "document": {
+        "a": "ab",
+        "b": "bc"
+      },
+      "result": [
+        "ab",
+        "bc"
+      ]
+    },
+    {
+      "name": "whitespace, selectors, return between comma and selector",
+      "selector": "$['a',\r'b']",
+      "document": {
+        "a": "ab",
+        "b": "bc"
+      },
+      "result": [
+        "ab",
+        "bc"
+      ]
+    },
+    {
+      "name": "whitespace, slice, space between start and colon",
+      "selector": "$[1 :5:2]",
+      "document": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ],
+      "result": [
+        2,
+        4
+      ]
+    },
+    {
+      "name": "whitespace, slice, newline between start and colon",
+      "selector": "$[1\n:5:2]",
+      "document": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ],
+      "result": [
+        2,
+        4
+      ]
+    },
+    {
+      "name": "whitespace, slice, tab between start and colon",
+      "selector": "$[1\t:5:2]",
+      "document": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ],
+      "result": [
+        2,
+        4
+      ]
+    },
+    {
+      "name": "whitespace, slice, return between start and colon",
+      "selector": "$[1\r:5:2]",
+      "document": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ],
+      "result": [
+        2,
+        4
+      ]
+    },
+    {
+      "name": "whitespace, slice, space between colon and end",
+      "selector": "$[1: 5:2]",
+      "document": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ],
+      "result": [
+        2,
+        4
+      ]
+    },
+    {
+      "name": "whitespace, slice, newline between colon and end",
+      "selector": "$[1:\n5:2]",
+      "document": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ],
+      "result": [
+        2,
+        4
+      ]
+    },
+    {
+      "name": "whitespace, slice, tab between colon and end",
+      "selector": "$[1:\t5:2]",
+      "document": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ],
+      "result": [
+        2,
+        4
+      ]
+    },
+    {
+      "name": "whitespace, slice, return between colon and end",
+      "selector": "$[1:\r5:2]",
+      "document": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ],
+      "result": [
+        2,
+        4
+      ]
+    },
+    {
+      "name": "whitespace, slice, space between end and colon",
+      "selector": "$[1:5 :2]",
+      "document": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ],
+      "result": [
+        2,
+        4
+      ]
+    },
+    {
+      "name": "whitespace, slice, newline between end and colon",
+      "selector": "$[1:5\n:2]",
+      "document": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ],
+      "result": [
+        2,
+        4
+      ]
+    },
+    {
+      "name": "whitespace, slice, tab between end and colon",
+      "selector": "$[1:5\t:2]",
+      "document": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ],
+      "result": [
+        2,
+        4
+      ]
+    },
+    {
+      "name": "whitespace, slice, return between end and colon",
+      "selector": "$[1:5\r:2]",
+      "document": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ],
+      "result": [
+        2,
+        4
+      ]
+    },
+    {
+      "name": "whitespace, slice, space between colon and step",
+      "selector": "$[1:5: 2]",
+      "document": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ],
+      "result": [
+        2,
+        4
+      ]
+    },
+    {
+      "name": "whitespace, slice, newline between colon and step",
+      "selector": "$[1:5:\n2]",
+      "document": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ],
+      "result": [
+        2,
+        4
+      ]
+    },
+    {
+      "name": "whitespace, slice, tab between colon and step",
+      "selector": "$[1:5:\t2]",
+      "document": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ],
+      "result": [
+        2,
+        4
+      ]
+    },
+    {
+      "name": "whitespace, slice, return between colon and step",
+      "selector": "$[1:5:\r2]",
+      "document": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ],
+      "result": [
+        2,
+        4
+      ]
     }
   ]
 }

--- a/tests/basic.json
+++ b/tests/basic.json
@@ -160,24 +160,9 @@
       ]
     },
     {
-      "name": "multiple selectors with whitespace",
-      "selector": "$[ 0 , 1 ]",
-      "document": [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9
-      ],
-      "result": [
-        0,
-        1
-      ]
+      "name": "multiple selectors, space instead of comma",
+      "selector": "$[0 2]",
+      "invalid_selector": true
     },
     {
       "name": "multiple selectors, name and index, array data",
@@ -321,7 +306,7 @@
     },
     {
       "name": "descendant segment, multiple selectors",
-      "selector" : "$..['a', 'd']",
+      "selector" : "$..['a','d']",
       "document" : [{"a": "b", "d": "e"}, {"a":"c", "d": "f"}],
       "result": [
         "b",

--- a/tests/functions/count.json
+++ b/tests/functions/count.json
@@ -39,8 +39,87 @@
       ]
     },
     {
-      "name": "non-array/string arg",
+      "name": "single-node arg",
+      "selector": "$[?count(@.a)>1]",
+      "document": [
+        {
+          "a": [
+            1,
+            2,
+            3
+          ]
+        },
+        {
+          "a": [
+            1
+          ],
+          "d": "f"
+        },
+        {
+          "a": 1,
+          "d": "f"
+        }
+      ],
+      "result": []
+    },
+    {
+      "name": "multiple-selector arg",
+      "selector": "$[?count(@['a','d'])>1]",
+      "document": [
+        {
+          "a": [
+            1,
+            2,
+            3
+          ]
+        },
+        {
+          "a": [
+            1
+          ],
+          "d": "f"
+        },
+        {
+          "a": 1,
+          "d": "f"
+        }
+      ],
+      "result": [
+        {
+          "a": [
+            1
+          ],
+          "d": "f"
+        },
+        {
+          "a": 1,
+          "d": "f"
+        }
+      ]
+    },
+    {
+      "name": "non-query arg, number",
       "selector": "$[?count(1)>2]",
+      "invalid_selector": true
+    },
+    {
+      "name": "non-query arg, string",
+      "selector": "$[?count('string')>2]",
+      "invalid_selector": true
+    },
+    {
+      "name": "non-query arg, true",
+      "selector": "$[?count(true)>2]",
+      "invalid_selector": true
+    },
+    {
+      "name": "non-query arg, false",
+      "selector": "$[?count(false)>2]",
+      "invalid_selector": true
+    },
+    {
+      "name": "non-query arg, null",
+      "selector": "$[?count(null)>2]",
       "invalid_selector": true
     },
     {

--- a/tests/functions/length.json
+++ b/tests/functions/length.json
@@ -29,8 +29,26 @@
       "result": []
     },
     {
-      "name": "non-array/string arg",
+      "name": "number arg",
       "selector" : "$[?length(1)>=2]",
+      "document" : [{"d": "f"}],
+      "result": []
+    },
+    {
+      "name": "true arg",
+      "selector" : "$[?length(true)>=2]",
+      "document" : [{"d": "f"}],
+      "result": []
+    },
+    {
+      "name": "false arg",
+      "selector" : "$[?length(false)>=2]",
+      "document" : [{"d": "f"}],
+      "result": []
+    },
+    {
+      "name": "null arg",
+      "selector" : "$[?length(null)>=2]",
       "document" : [{"d": "f"}],
       "result": []
     },

--- a/tests/whitespace/functions.json
+++ b/tests/whitespace/functions.json
@@ -1,0 +1,120 @@
+{
+  "tests": [
+    {
+      "name": "space between function name and parenthesis",
+      "selector" : "$[?count (@)==1]",
+      "invalid_selector": true
+    },
+    {
+      "name": "newline between function name and parenthesis",
+      "selector" : "$[?count\\n(@)==1]",
+      "invalid_selector": true
+    },
+    {
+      "name": "tab between function name and parenthesis",
+      "selector" : "$[?count\\t(@)==1]",
+      "invalid_selector": true
+    },
+    {
+      "name": "return between function name and parenthesis",
+      "selector" : "$[?count\\r(@)==1]",
+      "invalid_selector": true
+    },
+    {
+      "name": "space between parenthesis and arg",
+      "selector" : "$[?count( @)==1]",
+      "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1}, {"b": 2} ]
+    },
+    {
+      "name": "newline between parenthesis and arg",
+      "selector" : "$[?count(\\n@)==1]",
+      "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1}, {"b": 2} ]
+    },
+    {
+      "name": "tab between parenthesis and arg",
+      "selector" : "$[?count(\\t@)==1]",
+      "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1}, {"b": 2} ]
+    },
+    {
+      "name": "return between parenthesis and arg",
+      "selector" : "$[?count(\\r@)==1]",
+      "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1}, {"b": 2} ]
+    },
+    {
+      "name": "space between arg and comma",
+      "selector" : "$[?search(@ ,'[a-z]*')==1]",
+      "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1}, {"b": 2} ]
+    },
+    {
+      "name": "newline between arg and comma",
+      "selector" : "$[?search(@\\n,'[a-z]*')==1]",
+      "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1}, {"b": 2} ]
+    },
+    {
+      "name": "tab between arg and comma",
+      "selector" : "$[?search(@\\t,'[a-z]*')==1]",
+      "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1}, {"b": 2} ]
+    },
+    {
+      "name": "return between arg and comma",
+      "selector" : "$[?search(@\\r,'[a-z]*')==1]",
+      "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1}, {"b": 2} ]
+    },
+    {
+      "name": "space between comma and arg",
+      "selector" : "$[?search(@, '[a-z]*')==1]",
+      "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1}, {"b": 2} ]
+    },
+    {
+      "name": "newline between comma and arg",
+      "selector" : "$[?search(@,\\n'[a-z]*')==1]",
+      "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1}, {"b": 2} ]
+    },
+    {
+      "name": "tab between comma and arg",
+      "selector" : "$[?search(@,\\t'[a-z]*')==1]",
+      "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1}, {"b": 2} ]
+    },
+    {
+      "name": "return between comma and arg",
+      "selector" : "$[?search(@,\\r'[a-z]*')==1]",
+      "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1}, {"b": 2} ]
+    },
+    {
+      "name": "space between arg and parenthesis",
+      "selector" : "$[?count(@ )==1]",
+      "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1}, {"b": 2} ]
+    },
+    {
+      "name": "newline between arg and parenthesis",
+      "selector" : "$[?count(@\\n)==1]",
+      "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1}, {"b": 2} ]
+    },
+    {
+      "name": "tab between arg and parenthesis",
+      "selector" : "$[?count(@\\t)==1]",
+      "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1}, {"b": 2} ]
+    },
+    {
+      "name": "return between arg and parenthesis",
+      "selector" : "$[?count(@\\r)==1]",
+      "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1}, {"b": 2} ]
+    }
+  ]
+}

--- a/tests/whitespace/functions.json
+++ b/tests/whitespace/functions.json
@@ -46,51 +46,51 @@
     },
     {
       "name": "space between arg and comma",
-      "selector" : "$[?search(@ ,'[a-z]*')]",
-      "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
-      "result": [ {"a": 1}, {"b": 2} ]
+      "selector" : "$[?search(@ ,'[a-z]+')]",
+      "document" : [ "foo", "123" ],
+      "result": [ "foo" ]
     },
     {
       "name": "newline between arg and comma",
-      "selector" : "$[?search(@\n,'[a-z]*')]",
-      "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
-      "result": [ {"a": 1}, {"b": 2} ]
+      "selector" : "$[?search(@\n,'[a-z]+')]",
+      "document" : [ "foo", "123" ],
+      "result": [ "foo" ]
     },
     {
       "name": "tab between arg and comma",
-      "selector" : "$[?search(@\t,'[a-z]*')]",
-      "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
-      "result": [ {"a": 1}, {"b": 2} ]
+      "selector" : "$[?search(@\t,'[a-z]+')]",
+      "document" : [ "foo", "123" ],
+      "result": [ "foo" ]
     },
     {
       "name": "return between arg and comma",
-      "selector" : "$[?search(@\r,'[a-z]*')]",
-      "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
-      "result": [ {"a": 1}, {"b": 2} ]
+      "selector" : "$[?search(@\r,'[a-z]+')]",
+      "document" : [ "foo", "123" ],
+      "result": [ "foo" ]
     },
     {
       "name": "space between comma and arg",
-      "selector" : "$[?search(@, '[a-z]*')==1]",
-      "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
-      "result": [ {"a": 1}, {"b": 2} ]
+      "selector" : "$[?search(@, '[a-z]+')==1]",
+      "document" : [ "foo", "123" ],
+      "result": [ "foo" ]
     },
     {
       "name": "newline between comma and arg",
-      "selector" : "$[?search(@,\n'[a-z]*')]",
-      "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
-      "result": [ {"a": 1}, {"b": 2} ]
+      "selector" : "$[?search(@,\n'[a-z]+')]",
+      "document" : [ "foo", "123" ],
+      "result": [ "foo" ]
     },
     {
       "name": "tab between comma and arg",
-      "selector" : "$[?search(@,\t'[a-z]*')]",
-      "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
-      "result": [ {"a": 1}, {"b": 2} ]
+      "selector" : "$[?search(@,\t'[a-z]+')]",
+      "document" : [ "foo", "123" ],
+      "result": [ "foo" ]
     },
     {
       "name": "return between comma and arg",
-      "selector" : "$[?search(@,\r'[a-z]*')]",
-      "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
-      "result": [ {"a": 1}, {"b": 2} ]
+      "selector" : "$[?search(@,\r'[a-z]+')]",
+      "document" : [ "foo", "123" ],
+      "result": [ "foo" ]
     },
     {
       "name": "space between arg and parenthesis",

--- a/tests/whitespace/functions.json
+++ b/tests/whitespace/functions.json
@@ -7,17 +7,17 @@
     },
     {
       "name": "newline between function name and parenthesis",
-      "selector" : "$[?count\\n(@)==1]",
+      "selector" : "$[?count\n(@)==1]",
       "invalid_selector": true
     },
     {
       "name": "tab between function name and parenthesis",
-      "selector" : "$[?count\\t(@)==1]",
+      "selector" : "$[?count\t(@)==1]",
       "invalid_selector": true
     },
     {
       "name": "return between function name and parenthesis",
-      "selector" : "$[?count\\r(@)==1]",
+      "selector" : "$[?count\r(@)==1]",
       "invalid_selector": true
     },
     {
@@ -28,43 +28,43 @@
     },
     {
       "name": "newline between parenthesis and arg",
-      "selector" : "$[?count(\\n@)==1]",
+      "selector" : "$[?count(\n@)==1]",
       "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1}, {"b": 2} ]
     },
     {
       "name": "tab between parenthesis and arg",
-      "selector" : "$[?count(\\t@)==1]",
+      "selector" : "$[?count(\t@)==1]",
       "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1}, {"b": 2} ]
     },
     {
       "name": "return between parenthesis and arg",
-      "selector" : "$[?count(\\r@)==1]",
+      "selector" : "$[?count(\r@)==1]",
       "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1}, {"b": 2} ]
     },
     {
       "name": "space between arg and comma",
-      "selector" : "$[?search(@ ,'[a-z]*')==1]",
+      "selector" : "$[?search(@ ,'[a-z]*')]",
       "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1}, {"b": 2} ]
     },
     {
       "name": "newline between arg and comma",
-      "selector" : "$[?search(@\\n,'[a-z]*')==1]",
+      "selector" : "$[?search(@\n,'[a-z]*')]",
       "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1}, {"b": 2} ]
     },
     {
       "name": "tab between arg and comma",
-      "selector" : "$[?search(@\\t,'[a-z]*')==1]",
+      "selector" : "$[?search(@\t,'[a-z]*')]",
       "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1}, {"b": 2} ]
     },
     {
       "name": "return between arg and comma",
-      "selector" : "$[?search(@\\r,'[a-z]*')==1]",
+      "selector" : "$[?search(@\r,'[a-z]*')]",
       "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1}, {"b": 2} ]
     },
@@ -76,19 +76,19 @@
     },
     {
       "name": "newline between comma and arg",
-      "selector" : "$[?search(@,\\n'[a-z]*')==1]",
+      "selector" : "$[?search(@,\n'[a-z]*')]",
       "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1}, {"b": 2} ]
     },
     {
       "name": "tab between comma and arg",
-      "selector" : "$[?search(@,\\t'[a-z]*')==1]",
+      "selector" : "$[?search(@,\t'[a-z]*')]",
       "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1}, {"b": 2} ]
     },
     {
       "name": "return between comma and arg",
-      "selector" : "$[?search(@,\\r'[a-z]*')==1]",
+      "selector" : "$[?search(@,\r'[a-z]*')]",
       "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1}, {"b": 2} ]
     },
@@ -100,19 +100,19 @@
     },
     {
       "name": "newline between arg and parenthesis",
-      "selector" : "$[?count(@\\n)==1]",
+      "selector" : "$[?count(@\n)==1]",
       "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1}, {"b": 2} ]
     },
     {
       "name": "tab between arg and parenthesis",
-      "selector" : "$[?count(@\\t)==1]",
+      "selector" : "$[?count(@\t)==1]",
       "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1}, {"b": 2} ]
     },
     {
       "name": "return between arg and parenthesis",
-      "selector" : "$[?count(@\\r)==1]",
+      "selector" : "$[?count(@\r)==1]",
       "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1}, {"b": 2} ]
     }

--- a/tests/whitespace/functions.json
+++ b/tests/whitespace/functions.json
@@ -2,45 +2,45 @@
   "tests": [
     {
       "name": "space between function name and parenthesis",
-      "selector" : "$[?count (@)==1]",
+      "selector" : "$[?count (@.*)==1]",
       "invalid_selector": true
     },
     {
       "name": "newline between function name and parenthesis",
-      "selector" : "$[?count\n(@)==1]",
+      "selector" : "$[?count\n(@.*)==1]",
       "invalid_selector": true
     },
     {
       "name": "tab between function name and parenthesis",
-      "selector" : "$[?count\t(@)==1]",
+      "selector" : "$[?count\t(@.*)==1]",
       "invalid_selector": true
     },
     {
       "name": "return between function name and parenthesis",
-      "selector" : "$[?count\r(@)==1]",
+      "selector" : "$[?count\r(@.*)==1]",
       "invalid_selector": true
     },
     {
       "name": "space between parenthesis and arg",
-      "selector" : "$[?count( @)==1]",
+      "selector" : "$[?count( @.*)==1]",
       "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1}, {"b": 2} ]
     },
     {
       "name": "newline between parenthesis and arg",
-      "selector" : "$[?count(\n@)==1]",
+      "selector" : "$[?count(\n@.*)==1]",
       "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1}, {"b": 2} ]
     },
     {
       "name": "tab between parenthesis and arg",
-      "selector" : "$[?count(\t@)==1]",
+      "selector" : "$[?count(\t@.*)==1]",
       "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1}, {"b": 2} ]
     },
     {
       "name": "return between parenthesis and arg",
-      "selector" : "$[?count(\r@)==1]",
+      "selector" : "$[?count(\r@.*)==1]",
       "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1}, {"b": 2} ]
     },
@@ -70,7 +70,7 @@
     },
     {
       "name": "space between comma and arg",
-      "selector" : "$[?search(@, '[a-z]+')==1]",
+      "selector" : "$[?search(@, '[a-z]+')]",
       "document" : [ "foo", "123" ],
       "result": [ "foo" ]
     },
@@ -94,25 +94,25 @@
     },
     {
       "name": "space between arg and parenthesis",
-      "selector" : "$[?count(@ )==1]",
+      "selector" : "$[?count(@.* )==1]",
       "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1}, {"b": 2} ]
     },
     {
       "name": "newline between arg and parenthesis",
-      "selector" : "$[?count(@\n)==1]",
+      "selector" : "$[?count(@.*\n)==1]",
       "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1}, {"b": 2} ]
     },
     {
       "name": "tab between arg and parenthesis",
-      "selector" : "$[?count(@\t)==1]",
+      "selector" : "$[?count(@.*\t)==1]",
       "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1}, {"b": 2} ]
     },
     {
       "name": "return between arg and parenthesis",
-      "selector" : "$[?count(@\r)==1]",
+      "selector" : "$[?count(@.*\r)==1]",
       "document" : [ {"a": 1}, {"b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1}, {"b": 2} ]
     }

--- a/tests/whitespace/operators.json
+++ b/tests/whitespace/operators.json
@@ -1,7 +1,7 @@
 {
   "tests": [
     {
-      "name": "space before ==",
+      "name": "space before ||",
       "selector" : "$[?@.a ||@.b]",
       "document" : [ {"a": 1}, {"b": 2}, {"c": 3} ],
       "result": [ {"a": 1}, {"b": 2} ]

--- a/tests/whitespace/operators.json
+++ b/tests/whitespace/operators.json
@@ -1,0 +1,388 @@
+{
+  "tests": [
+    {
+      "name": "space before ==",
+      "selector" : "$[?@.a ||@.b]",
+      "document" : [ {"a": 1}, {"b": 2}, {"c": 3} ],
+      "result": [ {"a": 1}, {"b": 2} ]
+    },
+    {
+      "name": "newline before ||",
+      "selector" : "$[?@.a\\n||@.b]",
+      "document" : [ {"a": 1}, {"b": 2}, {"c": 3} ],
+      "result": [ {"a": 1}, {"b": 2} ]
+    },
+    {
+      "name": "tab before ||",
+      "selector" : "$[?@.a\\t||@.b]",
+      "document" : [ {"a": 1}, {"b": 2}, {"c": 3} ],
+      "result": [ {"a": 1}, {"b": 2} ]
+    },
+    {
+      "name": "return before ||",
+      "selector" : "$[?@.a\\r||@.b]",
+      "document" : [ {"a": 1}, {"b": 2}, {"c": 3} ],
+      "result": [ {"a": 1}, {"b": 2} ]
+    },
+    {
+      "name": "space after ||",
+      "selector" : "$[?@.a|| @.b]",
+      "document" : [ {"a": 1}, {"b": 2}, {"c": 3} ],
+      "result": [ {"a": 1}, {"b": 2} ]
+    },
+    {
+      "name": "newline after ||",
+      "selector" : "$[?@.a||\\n@.b]",
+      "document" : [ {"a": 1}, {"b": 2}, {"c": 3} ],
+      "result": [ {"a": 1}, {"b": 2} ]
+    },
+    {
+      "name": "tab after ||",
+      "selector" : "$[?@.a||\\t@.b]",
+      "document" : [ {"a": 1}, {"b": 2}, {"c": 3} ],
+      "result": [ {"a": 1}, {"b": 2} ]
+    },
+    {
+      "name": "return after ||",
+      "selector" : "$[?@.a||\\r@.b]",
+      "document" : [ {"a": 1}, {"b": 2}, {"c": 3} ],
+      "result": [ {"a": 1}, {"b": 2} ]
+    },
+    {
+      "name": "space before &&",
+      "selector" : "$[?@.a &&@.b]",
+      "document" : [ {"a": 1}, {"b": 2}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "newline before &&",
+      "selector" : "$[?@.a\\n&&@.b]",
+      "document" : [ {"a": 1}, {"b": 2}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "tab before &&",
+      "selector" : "$[?@.a\\t&&@.b]",
+      "document" : [ {"a": 1}, {"b": 2}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "return before &&",
+      "selector" : "$[?@.a\\r&&@.b]",
+      "document" : [ {"a": 1}, {"b": 2}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "space after &&",
+      "selector" : "$[?@.a&& @.b]",
+      "document" : [ {"a": 1}, {"b": 2}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "newline after &&",
+      "selector" : "$[?@.a&& @.b]",
+      "document" : [ {"a": 1}, {"b": 2}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "tab after &&",
+      "selector" : "$[?@.a&& @.b]",
+      "document" : [ {"a": 1}, {"b": 2}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "return after &&",
+      "selector" : "$[?@.a&& @.b]",
+      "document" : [ {"a": 1}, {"b": 2}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "space before ==",
+      "selector" : "$[?@.a ==@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 1} ]
+    },
+    {
+      "name": "newline before ==",
+      "selector" : "$[?@.a\\n==@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 1} ]
+    },
+    {
+      "name": "tab before ==",
+      "selector" : "$[?@.a\\t==@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 1} ]
+    },
+    {
+      "name": "return before ==",
+      "selector" : "$[?@.a\\r==@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 1} ]
+    },
+    {
+      "name": "space after ==",
+      "selector" : "$[?@.a== @.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 1} ]
+    },
+    {
+      "name": "newline after ==",
+      "selector" : "$[?@.a==\\n@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 1} ]
+    },
+    {
+      "name": "tab after ==",
+      "selector" : "$[?@.a==\\t@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 1} ]
+    },
+    {
+      "name": "return after ==",
+      "selector" : "$[?@.a==\\r@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 1} ]
+    },
+    {
+      "name": "space before !=",
+      "selector" : "$[?@.a !=@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "newline before !=",
+      "selector" : "$[?@.a\\n!=@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "tab before !=",
+      "selector" : "$[?@.a\\t!=@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "return before !=",
+      "selector" : "$[?@.a\\r!=@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "space after !=",
+      "selector" : "$[?@.a!= @.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "newline after !=",
+      "selector" : "$[?@.a!=\\n@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "tab after !=",
+      "selector" : "$[?@.a!=\\t@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "return after !=",
+      "selector" : "$[?@.a!=\\r@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "space before <",
+      "selector" : "$[?@.a <@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "newline before <",
+      "selector" : "$[?@.a\\n<@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "tab before <",
+      "selector" : "$[?@.a\\t<@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "return before <",
+      "selector" : "$[?@.a\\r<@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "space after <",
+      "selector" : "$[?@.a< @.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "newline after <",
+      "selector" : "$[?@.a<\\n@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "tab after <",
+      "selector" : "$[?@.a<\\t@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "return after <",
+      "selector" : "$[?@.a<\\r@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "space before >",
+      "selector" : "$[?@.b >@.a]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "newline before >",
+      "selector" : "$[?@.b\\n>@.a]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "tab before >",
+      "selector" : "$[?@.b\\t>@.a]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "return before >",
+      "selector" : "$[?@.b\\r>@.a]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "space after >",
+      "selector" : "$[?@.b> @.a]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "newline after >",
+      "selector" : "$[?@.b>\\n@.a]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "tab after >",
+      "selector" : "$[?@.b>\\t@.a]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "return after >",
+      "selector" : "$[?@.b>\\r@.a]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
+      "result": [ {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "space before <=",
+      "selector" : "$[?@.a <=@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "newline before <=",
+      "selector" : "$[?@.a\\n<=@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "tab before <=",
+      "selector" : "$[?@.a\\t<=@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "return before <=",
+      "selector" : "$[?@.a\\r<=@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "space after <=",
+      "selector" : "$[?@.a<= @.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "newline after <=",
+      "selector" : "$[?@.a<=\\n@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "tab after <=",
+      "selector" : "$[?@.a<=\\t@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "return after <=",
+      "selector" : "$[?@.a<=\\r@.b]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "space before >=",
+      "selector" : "$[?@.b >=@.a]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "newline before >=",
+      "selector" : "$[?@.b\\n>=@.a]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "tab before >=",
+      "selector" : "$[?@.b\\t>=@.a]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "return before >=",
+      "selector" : "$[?@.b\\r>=@.a]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "space after >=",
+      "selector" : "$[?@.b>= @.a]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "newline after >=",
+      "selector" : "$[?@.b>=\\n@.a]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "tab after >=",
+      "selector" : "$[?@.b>=\\t@.a]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "return after >=",
+      "selector" : "$[?@.b>=\\r@.a]",
+      "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
+      "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
+    }
+  ]
+}

--- a/tests/whitespace/operators.json
+++ b/tests/whitespace/operators.json
@@ -8,19 +8,19 @@
     },
     {
       "name": "newline before ||",
-      "selector" : "$[?@.a\\n||@.b]",
+      "selector" : "$[?@.a\n||@.b]",
       "document" : [ {"a": 1}, {"b": 2}, {"c": 3} ],
       "result": [ {"a": 1}, {"b": 2} ]
     },
     {
       "name": "tab before ||",
-      "selector" : "$[?@.a\\t||@.b]",
+      "selector" : "$[?@.a\t||@.b]",
       "document" : [ {"a": 1}, {"b": 2}, {"c": 3} ],
       "result": [ {"a": 1}, {"b": 2} ]
     },
     {
       "name": "return before ||",
-      "selector" : "$[?@.a\\r||@.b]",
+      "selector" : "$[?@.a\r||@.b]",
       "document" : [ {"a": 1}, {"b": 2}, {"c": 3} ],
       "result": [ {"a": 1}, {"b": 2} ]
     },
@@ -32,19 +32,19 @@
     },
     {
       "name": "newline after ||",
-      "selector" : "$[?@.a||\\n@.b]",
+      "selector" : "$[?@.a||\n@.b]",
       "document" : [ {"a": 1}, {"b": 2}, {"c": 3} ],
       "result": [ {"a": 1}, {"b": 2} ]
     },
     {
       "name": "tab after ||",
-      "selector" : "$[?@.a||\\t@.b]",
+      "selector" : "$[?@.a||\t@.b]",
       "document" : [ {"a": 1}, {"b": 2}, {"c": 3} ],
       "result": [ {"a": 1}, {"b": 2} ]
     },
     {
       "name": "return after ||",
-      "selector" : "$[?@.a||\\r@.b]",
+      "selector" : "$[?@.a||\r@.b]",
       "document" : [ {"a": 1}, {"b": 2}, {"c": 3} ],
       "result": [ {"a": 1}, {"b": 2} ]
     },
@@ -56,19 +56,19 @@
     },
     {
       "name": "newline before &&",
-      "selector" : "$[?@.a\\n&&@.b]",
+      "selector" : "$[?@.a\n&&@.b]",
       "document" : [ {"a": 1}, {"b": 2}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 2} ]
     },
     {
       "name": "tab before &&",
-      "selector" : "$[?@.a\\t&&@.b]",
+      "selector" : "$[?@.a\t&&@.b]",
       "document" : [ {"a": 1}, {"b": 2}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 2} ]
     },
     {
       "name": "return before &&",
-      "selector" : "$[?@.a\\r&&@.b]",
+      "selector" : "$[?@.a\r&&@.b]",
       "document" : [ {"a": 1}, {"b": 2}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 2} ]
     },
@@ -104,19 +104,19 @@
     },
     {
       "name": "newline before ==",
-      "selector" : "$[?@.a\\n==@.b]",
+      "selector" : "$[?@.a\n==@.b]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 1} ]
     },
     {
       "name": "tab before ==",
-      "selector" : "$[?@.a\\t==@.b]",
+      "selector" : "$[?@.a\t==@.b]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 1} ]
     },
     {
       "name": "return before ==",
-      "selector" : "$[?@.a\\r==@.b]",
+      "selector" : "$[?@.a\r==@.b]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 1} ]
     },
@@ -128,19 +128,19 @@
     },
     {
       "name": "newline after ==",
-      "selector" : "$[?@.a==\\n@.b]",
+      "selector" : "$[?@.a==\n@.b]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 1} ]
     },
     {
       "name": "tab after ==",
-      "selector" : "$[?@.a==\\t@.b]",
+      "selector" : "$[?@.a==\t@.b]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 1} ]
     },
     {
       "name": "return after ==",
-      "selector" : "$[?@.a==\\r@.b]",
+      "selector" : "$[?@.a==\r@.b]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 1} ]
     },
@@ -152,19 +152,19 @@
     },
     {
       "name": "newline before !=",
-      "selector" : "$[?@.a\\n!=@.b]",
+      "selector" : "$[?@.a\n!=@.b]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 2} ]
     },
     {
       "name": "tab before !=",
-      "selector" : "$[?@.a\\t!=@.b]",
+      "selector" : "$[?@.a\t!=@.b]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 2} ]
     },
     {
       "name": "return before !=",
-      "selector" : "$[?@.a\\r!=@.b]",
+      "selector" : "$[?@.a\r!=@.b]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 2} ]
     },
@@ -176,19 +176,19 @@
     },
     {
       "name": "newline after !=",
-      "selector" : "$[?@.a!=\\n@.b]",
+      "selector" : "$[?@.a!=\n@.b]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 2} ]
     },
     {
       "name": "tab after !=",
-      "selector" : "$[?@.a!=\\t@.b]",
+      "selector" : "$[?@.a!=\t@.b]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 2} ]
     },
     {
       "name": "return after !=",
-      "selector" : "$[?@.a!=\\r@.b]",
+      "selector" : "$[?@.a!=\r@.b]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 2} ]
     },
@@ -200,19 +200,19 @@
     },
     {
       "name": "newline before <",
-      "selector" : "$[?@.a\\n<@.b]",
+      "selector" : "$[?@.a\n<@.b]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 2} ]
     },
     {
       "name": "tab before <",
-      "selector" : "$[?@.a\\t<@.b]",
+      "selector" : "$[?@.a\t<@.b]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 2} ]
     },
     {
       "name": "return before <",
-      "selector" : "$[?@.a\\r<@.b]",
+      "selector" : "$[?@.a\r<@.b]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 2} ]
     },
@@ -224,19 +224,19 @@
     },
     {
       "name": "newline after <",
-      "selector" : "$[?@.a<\\n@.b]",
+      "selector" : "$[?@.a<\n@.b]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 2} ]
     },
     {
       "name": "tab after <",
-      "selector" : "$[?@.a<\\t@.b]",
+      "selector" : "$[?@.a<\t@.b]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 2} ]
     },
     {
       "name": "return after <",
-      "selector" : "$[?@.a<\\r@.b]",
+      "selector" : "$[?@.a<\r@.b]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 2} ]
     },
@@ -248,19 +248,19 @@
     },
     {
       "name": "newline before >",
-      "selector" : "$[?@.b\\n>@.a]",
+      "selector" : "$[?@.b\n>@.a]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 2} ]
     },
     {
       "name": "tab before >",
-      "selector" : "$[?@.b\\t>@.a]",
+      "selector" : "$[?@.b\t>@.a]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 2} ]
     },
     {
       "name": "return before >",
-      "selector" : "$[?@.b\\r>@.a]",
+      "selector" : "$[?@.b\r>@.a]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 2} ]
     },
@@ -272,19 +272,19 @@
     },
     {
       "name": "newline after >",
-      "selector" : "$[?@.b>\\n@.a]",
+      "selector" : "$[?@.b>\n@.a]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 2} ]
     },
     {
       "name": "tab after >",
-      "selector" : "$[?@.b>\\t@.a]",
+      "selector" : "$[?@.b>\t@.a]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 2} ]
     },
     {
       "name": "return after >",
-      "selector" : "$[?@.b>\\r@.a]",
+      "selector" : "$[?@.b>\r@.a]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ],
       "result": [ {"a": 1, "b": 2} ]
     },
@@ -296,19 +296,19 @@
     },
     {
       "name": "newline before <=",
-      "selector" : "$[?@.a\\n<=@.b]",
+      "selector" : "$[?@.a\n<=@.b]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
     },
     {
       "name": "tab before <=",
-      "selector" : "$[?@.a\\t<=@.b]",
+      "selector" : "$[?@.a\t<=@.b]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
     },
     {
       "name": "return before <=",
-      "selector" : "$[?@.a\\r<=@.b]",
+      "selector" : "$[?@.a\r<=@.b]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
     },
@@ -320,19 +320,19 @@
     },
     {
       "name": "newline after <=",
-      "selector" : "$[?@.a<=\\n@.b]",
+      "selector" : "$[?@.a<=\n@.b]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
     },
     {
       "name": "tab after <=",
-      "selector" : "$[?@.a<=\\t@.b]",
+      "selector" : "$[?@.a<=\t@.b]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
     },
     {
       "name": "return after <=",
-      "selector" : "$[?@.a<=\\r@.b]",
+      "selector" : "$[?@.a<=\r@.b]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
     },
@@ -344,19 +344,19 @@
     },
     {
       "name": "newline before >=",
-      "selector" : "$[?@.b\\n>=@.a]",
+      "selector" : "$[?@.b\n>=@.a]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
     },
     {
       "name": "tab before >=",
-      "selector" : "$[?@.b\\t>=@.a]",
+      "selector" : "$[?@.b\t>=@.a]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
     },
     {
       "name": "return before >=",
-      "selector" : "$[?@.b\\r>=@.a]",
+      "selector" : "$[?@.b\r>=@.a]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
     },
@@ -368,19 +368,19 @@
     },
     {
       "name": "newline after >=",
-      "selector" : "$[?@.b>=\\n@.a]",
+      "selector" : "$[?@.b>=\n@.a]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
     },
     {
       "name": "tab after >=",
-      "selector" : "$[?@.b>=\\t@.a]",
+      "selector" : "$[?@.b>=\t@.a]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
     },
     {
       "name": "return after >=",
-      "selector" : "$[?@.b>=\\r@.a]",
+      "selector" : "$[?@.b>=\r@.a]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
     }

--- a/tests/whitespace/selectors.json
+++ b/tests/whitespace/selectors.json
@@ -7,17 +7,17 @@
     },
     {
       "name": "newline between root and bracket",
-      "selector" : "$\\n['a']",
+      "selector" : "$\n['a']",
       "invalid_selector": true
     },
     {
       "name": "tab between root and bracket",
-      "selector" : "$\\t['a']",
+      "selector" : "$\t['a']",
       "invalid_selector": true
     },
     {
       "name": "return between root and bracket",
-      "selector" : "$\\r['a']",
+      "selector" : "$\r['a']",
       "invalid_selector": true
     },
     {
@@ -27,17 +27,17 @@
     },
     {
       "name": "newline between root and bracket",
-      "selector" : "$['a'] \\n['b']",
+      "selector" : "$['a'] \n['b']",
       "invalid_selector": true
     },
     {
       "name": "tab between root and bracket",
-      "selector" : "$['a'] \\t['b']",
+      "selector" : "$['a'] \t['b']",
       "invalid_selector": true
     },
     {
       "name": "return between root and bracket",
-      "selector" : "$['a'] \\r['b']",
+      "selector" : "$['a'] \r['b']",
       "invalid_selector": true
     },
     {
@@ -47,17 +47,17 @@
     },
     {
       "name": "newline between root and dot",
-      "selector" : "$\\n.a",
+      "selector" : "$\n.a",
       "invalid_selector": true
     },
     {
       "name": "tab between root and dot",
-      "selector" : "$\\t.a",
+      "selector" : "$\t.a",
       "invalid_selector": true
     },
     {
       "name": "return between root and dot",
-      "selector" : "$\\r.a",
+      "selector" : "$\r.a",
       "invalid_selector": true
     },
     {
@@ -67,17 +67,17 @@
     },
     {
       "name": "newline between dot and name",
-      "selector" : "$.\\na",
+      "selector" : "$.\na",
       "invalid_selector": true
     },
     {
       "name": "tab between dot and name",
-      "selector" : "$.\\ta",
+      "selector" : "$.\ta",
       "invalid_selector": true
     },
     {
       "name": "return between dot and name",
-      "selector" : "$.\\ra",
+      "selector" : "$.\ra",
       "invalid_selector": true
     },
     {
@@ -88,19 +88,19 @@
     },
     {
       "name": "newline between bracket and selector",
-      "selector" : "$[\\n'a']",
+      "selector" : "$[\n'a']",
       "document" : [{"a": "ab"}],
       "result": [ "ab" ]
     },
     {
       "name": "tab between bracket and selector",
-      "selector" : "$[\\t'a']",
+      "selector" : "$[\t'a']",
       "document" : [{"a": "ab"}],
       "result": [ "ab" ]
     },
     {
       "name": "return between bracket and selector",
-      "selector" : "$[\\r'a']",
+      "selector" : "$[\r'a']",
       "document" : [{"a": "ab"}],
       "result": [ "ab" ]
     },
@@ -112,19 +112,19 @@
     },
     {
       "name": "newline between selector and bracket",
-      "selector" : "$['a'\\n]",
+      "selector" : "$['a'\n]",
       "document" : [{"a": "ab"}],
       "result": [ "ab" ]
     },
     {
       "name": "tab between selector and bracket",
-      "selector" : "$['a'\\t]",
+      "selector" : "$['a'\t]",
       "document" : [{"a": "ab"}],
       "result": [ "ab" ]
     },
     {
       "name": "return between selector and bracket",
-      "selector" : "$['a'\\r]",
+      "selector" : "$['a'\r]",
       "document" : [{"a": "ab"}],
       "result": [ "ab" ]
     },
@@ -136,19 +136,19 @@
     },
     {
       "name": "newline between selector and comma",
-      "selector" : "$['a'\\n,'b']",
+      "selector" : "$['a'\n,'b']",
       "document" : [{"a": "ab", "b": "bc"}],
       "result": [ "ab", "bc" ]
     },
     {
       "name": "tab between selector and comma",
-      "selector" : "$['a'\\t,'b']",
+      "selector" : "$['a'\t,'b']",
       "document" : [{"a": "ab", "b": "bc"}],
       "result": [ "ab", "bc" ]
     },
     {
       "name": "return between selector and comma",
-      "selector" : "$['a'\\r,'b']",
+      "selector" : "$['a'\r,'b']",
       "document" : [{"a": "ab", "b": "bc"}],
       "result": [ "ab", "bc" ]
     },
@@ -160,19 +160,19 @@
     },
     {
       "name": "newline between comma and selector",
-      "selector" : "$['a',\\n'b']",
+      "selector" : "$['a',\n'b']",
       "document" : [{"a": "ab", "b": "bc"}],
       "result": [ "ab", "bc" ]
     },
     {
       "name": "tab between comma and selector",
-      "selector" : "$['a',\\t'b']",
+      "selector" : "$['a',\t'b']",
       "document" : [{"a": "ab", "b": "bc"}],
       "result": [ "ab", "bc" ]
     },
     {
       "name": "return between comma and selector",
-      "selector" : "$['a',\\r'b']",
+      "selector" : "$['a',\r'b']",
       "document" : [{"a": "ab", "b": "bc"}],
       "result": [ "ab", "bc" ]
     }

--- a/tests/whitespace/selectors.json
+++ b/tests/whitespace/selectors.json
@@ -1,0 +1,180 @@
+{
+  "tests": [
+    {
+      "name": "space between root and bracket",
+      "selector" : "$ ['a']",
+      "invalid_selector": true
+    },
+    {
+      "name": "newline between root and bracket",
+      "selector" : "$\\n['a']",
+      "invalid_selector": true
+    },
+    {
+      "name": "tab between root and bracket",
+      "selector" : "$\\t['a']",
+      "invalid_selector": true
+    },
+    {
+      "name": "return between root and bracket",
+      "selector" : "$\\r['a']",
+      "invalid_selector": true
+    },
+    {
+      "name": "space between bracket and bracket",
+      "selector" : "$['a'] ['b']",
+      "invalid_selector": true
+    },
+    {
+      "name": "newline between root and bracket",
+      "selector" : "$['a'] \\n['b']",
+      "invalid_selector": true
+    },
+    {
+      "name": "tab between root and bracket",
+      "selector" : "$['a'] \\t['b']",
+      "invalid_selector": true
+    },
+    {
+      "name": "return between root and bracket",
+      "selector" : "$['a'] \\r['b']",
+      "invalid_selector": true
+    },
+    {
+      "name": "space between root and dot",
+      "selector" : "$ .a",
+      "invalid_selector": true
+    },
+    {
+      "name": "newline between root and dot",
+      "selector" : "$\\n.a",
+      "invalid_selector": true
+    },
+    {
+      "name": "tab between root and dot",
+      "selector" : "$\\t.a",
+      "invalid_selector": true
+    },
+    {
+      "name": "return between root and dot",
+      "selector" : "$\\r.a",
+      "invalid_selector": true
+    },
+    {
+      "name": "space between dot and name",
+      "selector" : "$. a",
+      "invalid_selector": true
+    },
+    {
+      "name": "newline between dot and name",
+      "selector" : "$.\\na",
+      "invalid_selector": true
+    },
+    {
+      "name": "tab between dot and name",
+      "selector" : "$.\\ta",
+      "invalid_selector": true
+    },
+    {
+      "name": "return between dot and name",
+      "selector" : "$.\\ra",
+      "invalid_selector": true
+    },
+    {
+      "name": "space between bracket and selector",
+      "selector" : "$[ 'a']",
+      "document" : [{"a": "ab"}],
+      "result": [ "ab" ]
+    },
+    {
+      "name": "newline between bracket and selector",
+      "selector" : "$[\\n'a']",
+      "document" : [{"a": "ab"}],
+      "result": [ "ab" ]
+    },
+    {
+      "name": "tab between bracket and selector",
+      "selector" : "$[\\t'a']",
+      "document" : [{"a": "ab"}],
+      "result": [ "ab" ]
+    },
+    {
+      "name": "return between bracket and selector",
+      "selector" : "$[\\r'a']",
+      "document" : [{"a": "ab"}],
+      "result": [ "ab" ]
+    },
+    {
+      "name": "space between selector and bracket",
+      "selector" : "$['a' ]",
+      "document" : [{"a": "ab"}],
+      "result": [ "ab" ]
+    },
+    {
+      "name": "newline between selector and bracket",
+      "selector" : "$['a'\\n]",
+      "document" : [{"a": "ab"}],
+      "result": [ "ab" ]
+    },
+    {
+      "name": "tab between selector and bracket",
+      "selector" : "$['a'\\t]",
+      "document" : [{"a": "ab"}],
+      "result": [ "ab" ]
+    },
+    {
+      "name": "return between selector and bracket",
+      "selector" : "$['a'\\r]",
+      "document" : [{"a": "ab"}],
+      "result": [ "ab" ]
+    },
+    {
+      "name": "space between selector and comma",
+      "selector" : "$['a' ,'b']",
+      "document" : [{"a": "ab", "b": "bc"}],
+      "result": [ "ab", "bc" ]
+    },
+    {
+      "name": "newline between selector and comma",
+      "selector" : "$['a'\\n,'b']",
+      "document" : [{"a": "ab", "b": "bc"}],
+      "result": [ "ab", "bc" ]
+    },
+    {
+      "name": "tab between selector and comma",
+      "selector" : "$['a'\\t,'b']",
+      "document" : [{"a": "ab", "b": "bc"}],
+      "result": [ "ab", "bc" ]
+    },
+    {
+      "name": "return between selector and comma",
+      "selector" : "$['a'\\r,'b']",
+      "document" : [{"a": "ab", "b": "bc"}],
+      "result": [ "ab", "bc" ]
+    },
+    {
+      "name": "space between comma and selector",
+      "selector" : "$['a', 'b']",
+      "document" : [{"a": "ab", "b": "bc"}],
+      "result": [ "ab", "bc" ]
+    },
+    {
+      "name": "newline between comma and selector",
+      "selector" : "$['a',\\n'b']",
+      "document" : [{"a": "ab", "b": "bc"}],
+      "result": [ "ab", "bc" ]
+    },
+    {
+      "name": "tab between comma and selector",
+      "selector" : "$['a',\\t'b']",
+      "document" : [{"a": "ab", "b": "bc"}],
+      "result": [ "ab", "bc" ]
+    },
+    {
+      "name": "return between comma and selector",
+      "selector" : "$['a',\\r'b']",
+      "document" : [{"a": "ab", "b": "bc"}],
+      "result": [ "ab", "bc" ]
+    }
+  ]
+}

--- a/tests/whitespace/selectors.json
+++ b/tests/whitespace/selectors.json
@@ -81,99 +81,119 @@
       "invalid_selector": true
     },
     {
+      "name": "space between recursive descent and name",
+      "selector" : "$.. a",
+      "invalid_selector": true
+    },
+    {
+      "name": "newline between recursive descent and name",
+      "selector" : "$..\na",
+      "invalid_selector": true
+    },
+    {
+      "name": "tab between recursive descent and name",
+      "selector" : "$..\ta",
+      "invalid_selector": true
+    },
+    {
+      "name": "return between recursive descent and name",
+      "selector" : "$..\ra",
+      "invalid_selector": true
+    },
+    {
       "name": "space between bracket and selector",
       "selector" : "$[ 'a']",
-      "document" : [{"a": "ab"}],
+      "document" : {"a": "ab"},
       "result": [ "ab" ]
     },
     {
       "name": "newline between bracket and selector",
       "selector" : "$[\n'a']",
-      "document" : [{"a": "ab"}],
+      "document" : {"a": "ab"},
       "result": [ "ab" ]
     },
     {
       "name": "tab between bracket and selector",
       "selector" : "$[\t'a']",
-      "document" : [{"a": "ab"}],
+      "document" : {"a": "ab"},
       "result": [ "ab" ]
     },
     {
       "name": "return between bracket and selector",
       "selector" : "$[\r'a']",
-      "document" : [{"a": "ab"}],
+      "document" : {"a": "ab"},
       "result": [ "ab" ]
     },
     {
       "name": "space between selector and bracket",
       "selector" : "$['a' ]",
-      "document" : [{"a": "ab"}],
+      "document" : {"a": "ab"},
       "result": [ "ab" ]
     },
     {
       "name": "newline between selector and bracket",
       "selector" : "$['a'\n]",
-      "document" : [{"a": "ab"}],
+      "document" : {"a": "ab"},
       "result": [ "ab" ]
     },
     {
       "name": "tab between selector and bracket",
       "selector" : "$['a'\t]",
-      "document" : [{"a": "ab"}],
+      "document" : {"a": "ab"},
       "result": [ "ab" ]
     },
     {
       "name": "return between selector and bracket",
       "selector" : "$['a'\r]",
-      "document" : [{"a": "ab"}],
+      "document" : {"a": "ab"},
       "result": [ "ab" ]
     },
     {
       "name": "space between selector and comma",
       "selector" : "$['a' ,'b']",
-      "document" : [{"a": "ab", "b": "bc"}],
+      "document" : {"a": "ab", "b": "bc"},
       "result": [ "ab", "bc" ]
     },
     {
       "name": "newline between selector and comma",
       "selector" : "$['a'\n,'b']",
-      "document" : [{"a": "ab", "b": "bc"}],
+      "document" : {"a": "ab", "b": "bc"},
       "result": [ "ab", "bc" ]
     },
     {
       "name": "tab between selector and comma",
       "selector" : "$['a'\t,'b']",
-      "document" : [{"a": "ab", "b": "bc"}],
+      "document" : {"a": "ab", "b": "bc"},
       "result": [ "ab", "bc" ]
     },
     {
       "name": "return between selector and comma",
       "selector" : "$['a'\r,'b']",
-      "document" : [{"a": "ab", "b": "bc"}],
+      "document" : {"a": "ab", "b": "bc"},
       "result": [ "ab", "bc" ]
     },
     {
       "name": "space between comma and selector",
       "selector" : "$['a', 'b']",
-      "document" : [{"a": "ab", "b": "bc"}],
+      "document" : {"a": "ab", "b": "bc"},
       "result": [ "ab", "bc" ]
     },
     {
       "name": "newline between comma and selector",
       "selector" : "$['a',\n'b']",
-      "document" : [{"a": "ab", "b": "bc"}],
+      "document" : {"a": "ab", "b": "bc"},
       "result": [ "ab", "bc" ]
     },
     {
       "name": "tab between comma and selector",
       "selector" : "$['a',\t'b']",
-      "document" : [{"a": "ab", "b": "bc"}],
+      "document" : {"a": "ab", "b": "bc"},
       "result": [ "ab", "bc" ]
     },
     {
       "name": "return between comma and selector",
       "selector" : "$['a',\r'b']",
-      "document" : [{"a": "ab", "b": "bc"}],
+      "document" : {"a": "ab", "b": "bc"},
       "result": [ "ab", "bc" ]
     }
   ]

--- a/tests/whitespace/slice.json
+++ b/tests/whitespace/slice.json
@@ -1,0 +1,100 @@
+{
+  "tests": [
+    {
+      "name": "space between start and colon",
+      "selector" : "$[1 :5:2]",
+      "document" : [1,2,3,4,5],
+      "result": [ 1, 3 ]
+    },
+    {
+      "name": "newline between start and colon",
+      "selector" : "$[1\\n:5:2]",
+      "document" : [1,2,3,4,5],
+      "result": [ 1, 3 ]
+    },
+    {
+      "name": "tab between start and colon",
+      "selector" : "$[1\\t:5:2]",
+      "document" : [1,2,3,4,5],
+      "result": [ 1, 3 ]
+    },
+    {
+      "name": "return between start and colon",
+      "selector" : "$[1\\r:5:2]",
+      "document" : [1,2,3,4,5],
+      "result": [ 1, 3 ]
+    },
+    {
+      "name": "space between colon and end",
+      "selector" : "$[1: 5:2]",
+      "document" : [1,2,3,4,5],
+      "result": [ 1, 3 ]
+    },
+    {
+      "name": "newline between colon and end",
+      "selector" : "$[1:\\n5:2]",
+      "document" : [1,2,3,4,5],
+      "result": [ 1, 3 ]
+    },
+    {
+      "name": "tab between colon and end",
+      "selector" : "$[1:\\t5:2]",
+      "document" : [1,2,3,4,5],
+      "result": [ 1, 3 ]
+    },
+    {
+      "name": "return between colon and end",
+      "selector" : "$[1:\\r5:2]",
+      "document" : [1,2,3,4,5],
+      "result": [ 1, 3 ]
+    },
+    {
+      "name": "space between end and colon",
+      "selector" : "$[1:5 :2]",
+      "document" : [1,2,3,4,5],
+      "result": [ 1, 3 ]
+    },
+    {
+      "name": "newline between end and colon",
+      "selector" : "$[1:5\\n:2]",
+      "document" : [1,2,3,4,5],
+      "result": [ 1, 3 ]
+    },
+    {
+      "name": "tab between end and colon",
+      "selector" : "$[1:5\\t:2]",
+      "document" : [1,2,3,4,5],
+      "result": [ 1, 3 ]
+    },
+    {
+      "name": "return between end and colon",
+      "selector" : "$[1:5\\r:2]",
+      "document" : [1,2,3,4,5],
+      "result": [ 1, 3 ]
+    },
+    {
+      "name": "space between colon and step",
+      "selector" : "$[1:5: 2]",
+      "document" : [1,2,3,4,5],
+      "result": [ 1, 3 ]
+    },
+    {
+      "name": "newline between colon and step",
+      "selector" : "$[1:5:\\n2]",
+      "document" : [1,2,3,4,5],
+      "result": [ 1, 3 ]
+    },
+    {
+      "name": "tab between colon and step",
+      "selector" : "$[1:5:\\t2]",
+      "document" : [1,2,3,4,5],
+      "result": [ 1, 3 ]
+    },
+    {
+      "name": "return between colon and step",
+      "selector" : "$[1:5:\\r2]",
+      "document" : [1,2,3,4,5],
+      "result": [ 1, 3 ]
+    }
+  ]
+}

--- a/tests/whitespace/slice.json
+++ b/tests/whitespace/slice.json
@@ -8,19 +8,19 @@
     },
     {
       "name": "newline between start and colon",
-      "selector" : "$[1\\n:5:2]",
+      "selector" : "$[1\n:5:2]",
       "document" : [1,2,3,4,5],
       "result": [ 1, 3 ]
     },
     {
       "name": "tab between start and colon",
-      "selector" : "$[1\\t:5:2]",
+      "selector" : "$[1\t:5:2]",
       "document" : [1,2,3,4,5],
       "result": [ 1, 3 ]
     },
     {
       "name": "return between start and colon",
-      "selector" : "$[1\\r:5:2]",
+      "selector" : "$[1\r:5:2]",
       "document" : [1,2,3,4,5],
       "result": [ 1, 3 ]
     },
@@ -32,19 +32,19 @@
     },
     {
       "name": "newline between colon and end",
-      "selector" : "$[1:\\n5:2]",
+      "selector" : "$[1:\n5:2]",
       "document" : [1,2,3,4,5],
       "result": [ 1, 3 ]
     },
     {
       "name": "tab between colon and end",
-      "selector" : "$[1:\\t5:2]",
+      "selector" : "$[1:\t5:2]",
       "document" : [1,2,3,4,5],
       "result": [ 1, 3 ]
     },
     {
       "name": "return between colon and end",
-      "selector" : "$[1:\\r5:2]",
+      "selector" : "$[1:\r5:2]",
       "document" : [1,2,3,4,5],
       "result": [ 1, 3 ]
     },
@@ -56,19 +56,19 @@
     },
     {
       "name": "newline between end and colon",
-      "selector" : "$[1:5\\n:2]",
+      "selector" : "$[1:5\n:2]",
       "document" : [1,2,3,4,5],
       "result": [ 1, 3 ]
     },
     {
       "name": "tab between end and colon",
-      "selector" : "$[1:5\\t:2]",
+      "selector" : "$[1:5\t:2]",
       "document" : [1,2,3,4,5],
       "result": [ 1, 3 ]
     },
     {
       "name": "return between end and colon",
-      "selector" : "$[1:5\\r:2]",
+      "selector" : "$[1:5\r:2]",
       "document" : [1,2,3,4,5],
       "result": [ 1, 3 ]
     },
@@ -80,19 +80,19 @@
     },
     {
       "name": "newline between colon and step",
-      "selector" : "$[1:5:\\n2]",
+      "selector" : "$[1:5:\n2]",
       "document" : [1,2,3,4,5],
       "result": [ 1, 3 ]
     },
     {
       "name": "tab between colon and step",
-      "selector" : "$[1:5:\\t2]",
+      "selector" : "$[1:5:\t2]",
       "document" : [1,2,3,4,5],
       "result": [ 1, 3 ]
     },
     {
       "name": "return between colon and step",
-      "selector" : "$[1:5:\\r2]",
+      "selector" : "$[1:5:\r2]",
       "document" : [1,2,3,4,5],
       "result": [ 1, 3 ]
     }

--- a/tests/whitespace/slice.json
+++ b/tests/whitespace/slice.json
@@ -3,98 +3,98 @@
     {
       "name": "space between start and colon",
       "selector" : "$[1 :5:2]",
-      "document" : [1,2,3,4,5],
-      "result": [ 1, 3 ]
+      "document" : [1,2,3,4,5,6],
+      "result": [ 2, 4 ]
     },
     {
       "name": "newline between start and colon",
       "selector" : "$[1\n:5:2]",
-      "document" : [1,2,3,4,5],
-      "result": [ 1, 3 ]
+      "document" : [1,2,3,4,5,6],
+      "result": [ 2, 4 ]
     },
     {
       "name": "tab between start and colon",
       "selector" : "$[1\t:5:2]",
-      "document" : [1,2,3,4,5],
-      "result": [ 1, 3 ]
+      "document" : [1,2,3,4,5,6],
+      "result": [ 2, 4 ]
     },
     {
       "name": "return between start and colon",
       "selector" : "$[1\r:5:2]",
-      "document" : [1,2,3,4,5],
-      "result": [ 1, 3 ]
+      "document" : [1,2,3,4,5,6],
+      "result": [ 2, 4 ]
     },
     {
       "name": "space between colon and end",
       "selector" : "$[1: 5:2]",
-      "document" : [1,2,3,4,5],
-      "result": [ 1, 3 ]
+      "document" : [1,2,3,4,5,6],
+      "result": [ 2, 4 ]
     },
     {
       "name": "newline between colon and end",
       "selector" : "$[1:\n5:2]",
-      "document" : [1,2,3,4,5],
-      "result": [ 1, 3 ]
+      "document" : [1,2,3,4,5,6],
+      "result": [ 2, 4 ]
     },
     {
       "name": "tab between colon and end",
       "selector" : "$[1:\t5:2]",
-      "document" : [1,2,3,4,5],
-      "result": [ 1, 3 ]
+      "document" : [1,2,3,4,5,6],
+      "result": [ 2, 4 ]
     },
     {
       "name": "return between colon and end",
       "selector" : "$[1:\r5:2]",
-      "document" : [1,2,3,4,5],
-      "result": [ 1, 3 ]
+      "document" : [1,2,3,4,5,6],
+      "result": [ 2, 4 ]
     },
     {
       "name": "space between end and colon",
       "selector" : "$[1:5 :2]",
-      "document" : [1,2,3,4,5],
-      "result": [ 1, 3 ]
+      "document" : [1,2,3,4,5,6],
+      "result": [ 2, 4 ]
     },
     {
       "name": "newline between end and colon",
       "selector" : "$[1:5\n:2]",
-      "document" : [1,2,3,4,5],
-      "result": [ 1, 3 ]
+      "document" : [1,2,3,4,5,6],
+      "result": [ 2, 4 ]
     },
     {
       "name": "tab between end and colon",
       "selector" : "$[1:5\t:2]",
-      "document" : [1,2,3,4,5],
-      "result": [ 1, 3 ]
+      "document" : [1,2,3,4,5,6],
+      "result": [ 2, 4 ]
     },
     {
       "name": "return between end and colon",
       "selector" : "$[1:5\r:2]",
-      "document" : [1,2,3,4,5],
-      "result": [ 1, 3 ]
+      "document" : [1,2,3,4,5,6],
+      "result": [ 2, 4 ]
     },
     {
       "name": "space between colon and step",
       "selector" : "$[1:5: 2]",
-      "document" : [1,2,3,4,5],
-      "result": [ 1, 3 ]
+      "document" : [1,2,3,4,5,6],
+      "result": [ 2, 4 ]
     },
     {
       "name": "newline between colon and step",
       "selector" : "$[1:5:\n2]",
-      "document" : [1,2,3,4,5],
-      "result": [ 1, 3 ]
+      "document" : [1,2,3,4,5,6],
+      "result": [ 2, 4 ]
     },
     {
       "name": "tab between colon and step",
       "selector" : "$[1:5:\t2]",
-      "document" : [1,2,3,4,5],
-      "result": [ 1, 3 ]
+      "document" : [1,2,3,4,5,6],
+      "result": [ 2, 4 ]
     },
     {
       "name": "return between colon and step",
       "selector" : "$[1:5:\r2]",
-      "document" : [1,2,3,4,5],
-      "result": [ 1, 3 ]
+      "document" : [1,2,3,4,5,6],
+      "result": [ 2, 4 ]
     }
   ]
 }


### PR DESCRIPTION
Resolves #16

I haven't pushed the _cts.json_ changes, though I was able to rebuild it locally.  Not sure if that's done automatically yet.  If not, I'll go ahead and push those changes.

Supported whitespace includes

- space
- tab
- carriage return
- newline

These tests check all of those.  ~My implementation doesn't seem to like some of them yet.  Haven't been able to test whether that's my implementation or something about the way I wrote the tests.  Will continue to check.~