### PR TITLE
Cover whitespace in and around filter selectors

### DIFF
--- a/cts.json
+++ b/cts.json
@@ -3968,6 +3968,326 @@
       "invalid_selector": true
     },
     {
+      "name": "whitespace, filter, space between question mark and expression",
+      "selector": "$[? @.a]",
+      "document": [
+        {
+          "a": "b",
+          "d": "e"
+        },
+        {
+          "b": "c",
+          "d": "f"
+        }
+      ],
+      "result": [
+        {
+          "a": "b",
+          "d": "e"
+        }
+      ]
+    },
+    {
+      "name": "whitespace, filter, newline between question mark and expression",
+      "selector": "$[?\n@.a]",
+      "document": [
+        {
+          "a": "b",
+          "d": "e"
+        },
+        {
+          "b": "c",
+          "d": "f"
+        }
+      ],
+      "result": [
+        {
+          "a": "b",
+          "d": "e"
+        }
+      ]
+    },
+    {
+      "name": "whitespace, filter, tab between question mark and expression",
+      "selector": "$[?\t@.a]",
+      "document": [
+        {
+          "a": "b",
+          "d": "e"
+        },
+        {
+          "b": "c",
+          "d": "f"
+        }
+      ],
+      "result": [
+        {
+          "a": "b",
+          "d": "e"
+        }
+      ]
+    },
+    {
+      "name": "whitespace, filter, return between question mark and expression",
+      "selector": "$[?\r@.a]",
+      "document": [
+        {
+          "a": "b",
+          "d": "e"
+        },
+        {
+          "b": "c",
+          "d": "f"
+        }
+      ],
+      "result": [
+        {
+          "a": "b",
+          "d": "e"
+        }
+      ]
+    },
+    {
+      "name": "whitespace, filter, space between question mark and parenthesized expression",
+      "selector": "$[? (@.a)]",
+      "document": [
+        {
+          "a": "b",
+          "d": "e"
+        },
+        {
+          "b": "c",
+          "d": "f"
+        }
+      ],
+      "result": [
+        {
+          "a": "b",
+          "d": "e"
+        }
+      ]
+    },
+    {
+      "name": "whitespace, filter, newline between question mark and parenthesized expression",
+      "selector": "$[?\n(@.a)]",
+      "document": [
+        {
+          "a": "b",
+          "d": "e"
+        },
+        {
+          "b": "c",
+          "d": "f"
+        }
+      ],
+      "result": [
+        {
+          "a": "b",
+          "d": "e"
+        }
+      ]
+    },
+    {
+      "name": "whitespace, filter, tab between question mark and parenthesized expression",
+      "selector": "$[?\t(@.a)]",
+      "document": [
+        {
+          "a": "b",
+          "d": "e"
+        },
+        {
+          "b": "c",
+          "d": "f"
+        }
+      ],
+      "result": [
+        {
+          "a": "b",
+          "d": "e"
+        }
+      ]
+    },
+    {
+      "name": "whitespace, filter, return between question mark and parenthesized expression",
+      "selector": "$[?\r(@.a)]",
+      "document": [
+        {
+          "a": "b",
+          "d": "e"
+        },
+        {
+          "b": "c",
+          "d": "f"
+        }
+      ],
+      "result": [
+        {
+          "a": "b",
+          "d": "e"
+        }
+      ]
+    },
+    {
+      "name": "whitespace, filter, space between parenthesized expression and bracket",
+      "selector": "$[?(@.a) ]",
+      "document": [
+        {
+          "a": "b",
+          "d": "e"
+        },
+        {
+          "b": "c",
+          "d": "f"
+        }
+      ],
+      "result": [
+        {
+          "a": "b",
+          "d": "e"
+        }
+      ]
+    },
+    {
+      "name": "whitespace, filter, newline between parenthesized expression and bracket",
+      "selector": "$[?(@.a)\n]",
+      "document": [
+        {
+          "a": "b",
+          "d": "e"
+        },
+        {
+          "b": "c",
+          "d": "f"
+        }
+      ],
+      "result": [
+        {
+          "a": "b",
+          "d": "e"
+        }
+      ]
+    },
+    {
+      "name": "whitespace, filter, tab between parenthesized expression and bracket",
+      "selector": "$[?(@.a)\t]",
+      "document": [
+        {
+          "a": "b",
+          "d": "e"
+        },
+        {
+          "b": "c",
+          "d": "f"
+        }
+      ],
+      "result": [
+        {
+          "a": "b",
+          "d": "e"
+        }
+      ]
+    },
+    {
+      "name": "whitespace, filter, return between parenthesized expression and bracket",
+      "selector": "$[?(@.a)\r]",
+      "document": [
+        {
+          "a": "b",
+          "d": "e"
+        },
+        {
+          "b": "c",
+          "d": "f"
+        }
+      ],
+      "result": [
+        {
+          "a": "b",
+          "d": "e"
+        }
+      ]
+    },
+    {
+      "name": "whitespace, filter, space between bracket and question mark",
+      "selector": "$[ ?@.a]",
+      "document": [
+        {
+          "a": "b",
+          "d": "e"
+        },
+        {
+          "b": "c",
+          "d": "f"
+        }
+      ],
+      "result": [
+        {
+          "a": "b",
+          "d": "e"
+        }
+      ]
+    },
+    {
+      "name": "whitespace, filter, newline between bracket and question mark",
+      "selector": "$[\n?@.a]",
+      "document": [
+        {
+          "a": "b",
+          "d": "e"
+        },
+        {
+          "b": "c",
+          "d": "f"
+        }
+      ],
+      "result": [
+        {
+          "a": "b",
+          "d": "e"
+        }
+      ]
+    },
+    {
+      "name": "whitespace, filter, tab between bracket and question mark",
+      "selector": "$[\t?@.a]",
+      "document": [
+        {
+          "a": "b",
+          "d": "e"
+        },
+        {
+          "b": "c",
+          "d": "f"
+        }
+      ],
+      "result": [
+        {
+          "a": "b",
+          "d": "e"
+        }
+      ]
+    },
+    {
+      "name": "whitespace, filter, return between bracket and question mark",
+      "selector": "$[\r?@.a]",
+      "document": [
+        {
+          "a": "b",
+          "d": "e"
+        },
+        {
+          "b": "c",
+          "d": "f"
+        }
+      ],
+      "result": [
+        {
+          "a": "b",
+          "d": "e"
+        }
+      ]
+    },
+    {
       "name": "whitespace, functions, space between function name and parenthesis",
       "selector": "$[?count (@.*)==1]",
       "invalid_selector": true

--- a/tests/whitespace/filter.json
+++ b/tests/whitespace/filter.json
@@ -1,0 +1,132 @@
+{
+  "tests": [
+    {
+      "name": "space between question mark and expression",
+      "selector" : "$[? @.a]",
+      "document" : [{"a": "b", "d": "e"}, {"b": "c", "d": "f"}],
+      "result": [
+        {"a": "b", "d": "e"}
+      ]
+    },
+    {
+      "name": "newline between question mark and expression",
+      "selector" : "$[?\n@.a]",
+      "document" : [{"a": "b", "d": "e"}, {"b": "c", "d": "f"}],
+      "result": [
+        {"a": "b", "d": "e"}
+      ]
+    },
+    {
+      "name": "tab between question mark and expression",
+      "selector" : "$[?\t@.a]",
+      "document" : [{"a": "b", "d": "e"}, {"b": "c", "d": "f"}],
+      "result": [
+        {"a": "b", "d": "e"}
+      ]
+    },
+    {
+      "name": "return between question mark and expression",
+      "selector" : "$[?\r@.a]",
+      "document" : [{"a": "b", "d": "e"}, {"b": "c", "d": "f"}],
+      "result": [
+        {"a": "b", "d": "e"}
+      ]
+    },
+    {
+      "name": "space between question mark and parenthesized expression",
+      "selector" : "$[? (@.a)]",
+      "document" : [{"a": "b", "d": "e"}, {"b": "c", "d": "f"}],
+      "result": [
+        {"a": "b", "d": "e"}
+      ]
+    },
+    {
+      "name": "newline between question mark and parenthesized expression",
+      "selector" : "$[?\n(@.a)]",
+      "document" : [{"a": "b", "d": "e"}, {"b": "c", "d": "f"}],
+      "result": [
+        {"a": "b", "d": "e"}
+      ]
+    },
+    {
+      "name": "tab between question mark and parenthesized expression",
+      "selector" : "$[?\t(@.a)]",
+      "document" : [{"a": "b", "d": "e"}, {"b": "c", "d": "f"}],
+      "result": [
+        {"a": "b", "d": "e"}
+      ]
+    },
+    {
+      "name": "return between question mark and parenthesized expression",
+      "selector" : "$[?\r(@.a)]",
+      "document" : [{"a": "b", "d": "e"}, {"b": "c", "d": "f"}],
+      "result": [
+        {"a": "b", "d": "e"}
+      ]
+    },
+    {
+      "name": "space between parenthesized expression and bracket",
+      "selector" : "$[?(@.a) ]",
+      "document" : [{"a": "b", "d": "e"}, {"b": "c", "d": "f"}],
+      "result": [
+        {"a": "b", "d": "e"}
+      ]
+    },
+    {
+      "name": "newline between parenthesized expression and bracket",
+      "selector" : "$[?(@.a)\n]",
+      "document" : [{"a": "b", "d": "e"}, {"b": "c", "d": "f"}],
+      "result": [
+        {"a": "b", "d": "e"}
+      ]
+    },
+    {
+      "name": "tab between parenthesized expression and bracket",
+      "selector" : "$[?(@.a)\t]",
+      "document" : [{"a": "b", "d": "e"}, {"b": "c", "d": "f"}],
+      "result": [
+        {"a": "b", "d": "e"}
+      ]
+    },
+    {
+      "name": "return between parenthesized expression and bracket",
+      "selector" : "$[?(@.a)\r]",
+      "document" : [{"a": "b", "d": "e"}, {"b": "c", "d": "f"}],
+      "result": [
+        {"a": "b", "d": "e"}
+      ]
+    },
+    {
+      "name": "space between bracket and question mark",
+      "selector" : "$[ ?@.a]",
+      "document" : [{"a": "b", "d": "e"}, {"b": "c", "d": "f"}],
+      "result": [
+        {"a": "b", "d": "e"}
+      ]
+    },
+    {
+      "name": "newline between bracket and question mark",
+      "selector" : "$[\n?@.a]",
+      "document" : [{"a": "b", "d": "e"}, {"b": "c", "d": "f"}],
+      "result": [
+        {"a": "b", "d": "e"}
+      ]
+    },
+    {
+      "name": "tab between bracket and question mark",
+      "selector" : "$[\t?@.a]",
+      "document" : [{"a": "b", "d": "e"}, {"b": "c", "d": "f"}],
+      "result": [
+        {"a": "b", "d": "e"}
+      ]
+    },
+    {
+      "name": "return between bracket and question mark",
+      "selector" : "$[\r?@.a]",
+      "document" : [{"a": "b", "d": "e"}, {"b": "c", "d": "f"}],
+      "result": [
+        {"a": "b", "d": "e"}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Cover whitespace in and around filter selectors. Closes #44.

I note that there is arguably nothing special about whitespace around parenthesized expressions, and choosing to test cases such as "space between question mark and parenthesized expression" might be considered a little arbitrary, compared to any other filter expression not surrounded by parentheses.

Similarly, one might consider there to be unnecessary overlap between "space between bracket and question mark" etc. and cases from `whitespace/selectors.json`.  I would understand if these test cases need to be removed.