### PR TITLE
Cover whitespace between logical not and expr

### DIFF
--- a/cts.json
+++ b/cts.json
@@ -6455,6 +6455,206 @@
       ]
     },
     {
+      "name": "whitespace, operators, space between logical not and test expression",
+      "selector": "$[?! @.a]",
+      "document": [
+        {
+          "a": "a",
+          "d": "e"
+        },
+        {
+          "d": "f"
+        },
+        {
+          "a": "d",
+          "d": "f"
+        }
+      ],
+      "result": [
+        {
+          "d": "f"
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, newline between logical not and test expression",
+      "selector": "$[?!\n@.a]",
+      "document": [
+        {
+          "a": "a",
+          "d": "e"
+        },
+        {
+          "d": "f"
+        },
+        {
+          "a": "d",
+          "d": "f"
+        }
+      ],
+      "result": [
+        {
+          "d": "f"
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, tab between logical not and test expression",
+      "selector": "$[?!\t@.a]",
+      "document": [
+        {
+          "a": "a",
+          "d": "e"
+        },
+        {
+          "d": "f"
+        },
+        {
+          "a": "d",
+          "d": "f"
+        }
+      ],
+      "result": [
+        {
+          "d": "f"
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, return between logical not and test expression",
+      "selector": "$[?!\r@.a]",
+      "document": [
+        {
+          "a": "a",
+          "d": "e"
+        },
+        {
+          "d": "f"
+        },
+        {
+          "a": "d",
+          "d": "f"
+        }
+      ],
+      "result": [
+        {
+          "d": "f"
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, space between logical not and parenthesized expression",
+      "selector": "$[?! (@.a=='b')]",
+      "document": [
+        {
+          "a": "a",
+          "d": "e"
+        },
+        {
+          "a": "b",
+          "d": "f"
+        },
+        {
+          "a": "d",
+          "d": "f"
+        }
+      ],
+      "result": [
+        {
+          "a": "a",
+          "d": "e"
+        },
+        {
+          "a": "d",
+          "d": "f"
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, newline between logical not and parenthesized expression",
+      "selector": "$[?!\n(@.a=='b')]",
+      "document": [
+        {
+          "a": "a",
+          "d": "e"
+        },
+        {
+          "a": "b",
+          "d": "f"
+        },
+        {
+          "a": "d",
+          "d": "f"
+        }
+      ],
+      "result": [
+        {
+          "a": "a",
+          "d": "e"
+        },
+        {
+          "a": "d",
+          "d": "f"
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, tab between logical not and parenthesized expression",
+      "selector": "$[?!\t(@.a=='b')]",
+      "document": [
+        {
+          "a": "a",
+          "d": "e"
+        },
+        {
+          "a": "b",
+          "d": "f"
+        },
+        {
+          "a": "d",
+          "d": "f"
+        }
+      ],
+      "result": [
+        {
+          "a": "a",
+          "d": "e"
+        },
+        {
+          "a": "d",
+          "d": "f"
+        }
+      ]
+    },
+    {
+      "name": "whitespace, operators, return between logical not and parenthesized expression",
+      "selector": "$[?!\r(@.a=='b')]",
+      "document": [
+        {
+          "a": "a",
+          "d": "e"
+        },
+        {
+          "a": "b",
+          "d": "f"
+        },
+        {
+          "a": "d",
+          "d": "f"
+        }
+      ],
+      "result": [
+        {
+          "a": "a",
+          "d": "e"
+        },
+        {
+          "a": "d",
+          "d": "f"
+        }
+      ]
+    },
+    {
       "name": "whitespace, selectors, space between root and bracket",
       "selector": "$ ['a']",
       "document": {

--- a/tests/whitespace/operators.json
+++ b/tests/whitespace/operators.json
@@ -383,6 +383,74 @@
       "selector" : "$[?@.b>=\r@.a]",
       "document" : [ {"a": 1, "b": 1}, {"a": 1, "b": 2}, {"a": 2, "b": 1} ],
       "result": [ {"a": 1, "b": 1}, {"a": 1, "b": 2} ]
+    },
+    {
+      "name": "space between logical not and test expression",
+      "selector": "$[?! @.a]",
+      "document" : [{"a": "a", "d": "e"}, {"d": "f"}, {"a": "d", "d": "f"}],
+      "result": [
+        {"d": "f"}
+      ]
+    },
+    {
+      "name": "newline between logical not and test expression",
+      "selector": "$[?!\n@.a]",
+      "document" : [{"a": "a", "d": "e"}, {"d": "f"}, {"a": "d", "d": "f"}],
+      "result": [
+        {"d": "f"}
+      ]
+    },
+    {
+      "name": "tab between logical not and test expression",
+      "selector": "$[?!\t@.a]",
+      "document" : [{"a": "a", "d": "e"}, {"d": "f"}, {"a": "d", "d": "f"}],
+      "result": [
+        {"d": "f"}
+      ]
+    },
+    {
+      "name": "return between logical not and test expression",
+      "selector": "$[?!\r@.a]",
+      "document" : [{"a": "a", "d": "e"}, {"d": "f"}, {"a": "d", "d": "f"}],
+      "result": [
+        {"d": "f"}
+      ]
+    },
+    {
+      "name": "space between logical not and parenthesized expression",
+      "selector": "$[?! (@.a=='b')]",
+      "document" : [{"a": "a", "d": "e"}, {"a": "b", "d": "f"}, {"a": "d", "d": "f"}],
+      "result": [
+        {"a": "a", "d": "e"},
+        {"a": "d", "d": "f"}
+      ]
+    },
+    {
+      "name": "newline between logical not and parenthesized expression",
+      "selector": "$[?!\n(@.a=='b')]",
+      "document" : [{"a": "a", "d": "e"}, {"a": "b", "d": "f"}, {"a": "d", "d": "f"}],
+      "result": [
+        {"a": "a", "d": "e"},
+        {"a": "d", "d": "f"}
+      ]
+    },
+    {
+      "name": "tab between logical not and parenthesized expression",
+      "selector": "$[?!\t(@.a=='b')]",
+      "document" : [{"a": "a", "d": "e"}, {"a": "b", "d": "f"}, {"a": "d", "d": "f"}],
+      "result": [
+        {"a": "a", "d": "e"},
+        {"a": "d", "d": "f"}
+      ]
+    },
+    {
+      "name": "return between logical not and parenthesized expression",
+      "selector": "$[?!\r(@.a=='b')]",
+      "document" : [{"a": "a", "d": "e"}, {"a": "b", "d": "f"}, {"a": "d", "d": "f"}],
+      "result": [
+        {"a": "a", "d": "e"},
+        {"a": "d", "d": "f"}
+      ]
     }
   ]
 }


### PR DESCRIPTION
Cover whitespace between the logical not operator and a test expression or parenthesized expression.

For reference, this is the relevant part of the grammar.

```plain
paren-expr          = [logical-not-op S] "(" S logical-expr S ")"
                                        ; parenthesized expression
logical-not-op      = "!"               ; logical NOT operator
test-expr           = [logical-not-op S]
                     (filter-query / ; existence/non-existence
                      function-expr) ; LogicalType or
                                     ; NodesType
```