### PR TITLE
Cover empty name selectors

### DIFF
--- a/cts.json
+++ b/cts.json
@@ -2935,6 +2935,30 @@
       "invalid_selector": true
     },
     {
+      "name": "name selector, double quotes, empty",
+      "selector": "$[\"\"]",
+      "document": {
+        "a": "A",
+        "b": "B",
+        "": "C"
+      },
+      "result": [
+        "C"
+      ]
+    },
+    {
+      "name": "name selector, single quotes, empty",
+      "selector": "$['']",
+      "document": {
+        "a": "A",
+        "b": "B",
+        "": "C"
+      },
+      "result": [
+        "C"
+      ]
+    },
+    {
       "name": "slice selector, slice selector",
       "selector": "$[1:3]",
       "document": [

--- a/tests/name_selector.json
+++ b/tests/name_selector.json
@@ -667,6 +667,30 @@
       "name": "single quotes, incomplete escape",
       "selector": "$['\\']",
       "invalid_selector": true
+    },
+    {
+      "name": "double quotes, empty",
+      "selector": "$[\"\"]",
+      "document": {
+        "a": "A",
+        "b": "B",
+        "": "C"
+      },
+      "result": [
+        "C"
+      ]
+    },
+    {
+      "name": "single quotes, empty",
+      "selector": "$['']",
+      "document": {
+        "a": "A",
+        "b": "B",
+        "": "C"
+      },
+      "result": [
+        "C"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Cover name selectors that are an empty string literal. Like `$['']` and `$[""]`.