### PR TITLE
Cover expressions as function arguments

### DIFF
--- a/cts.json
+++ b/cts.json
@@ -3820,6 +3820,48 @@
       "invalid_selector": true
     },
     {
+      "name": "functions, arguments, parenthesized expression",
+      "selector": "$[?match((@.a), ('a.*'))]",
+      "document": [
+        {
+          "a": "ab"
+        },
+        {
+          "a": "ba"
+        }
+      ],
+      "result": [
+        {
+          "a": "ab"
+        }
+      ]
+    },
+    {
+      "name": "functions, arguments, function expression",
+      "selector": "$.values[?match(@.a, value($..['regex']))]",
+      "document": {
+        "regex": "a.*",
+        "values": [
+          {
+            "a": "ab"
+          },
+          {
+            "a": "ba"
+          }
+        ]
+      },
+      "result": [
+        {
+          "a": "ab"
+        }
+      ]
+    },
+    {
+      "name": "functions, arguments, type mismatch, value type and logical type",
+      "selector": "$[?length(@.a==@.b)>2]",
+      "invalid_selector": true
+    },
+    {
       "name": "functions, count, count function",
       "selector": "$[?count(@..*)>2]",
       "document": [

--- a/tests/functions/arguments.json
+++ b/tests/functions/arguments.json
@@ -1,0 +1,25 @@
+{
+  "tests": [
+    {
+      "name": "parenthesized expression",
+      "selector": "$[?match((@.a), ('a.*'))]",
+      "document" : [{"a": "ab"}, {"a": "ba"}],
+      "result": [
+        {"a": "ab"}
+      ]
+    },
+    {
+      "name": "function expression",
+      "selector": "$.values[?match(@.a, value($..['regex']))]",
+      "document" : {"regex": "a.*", "values": [{"a": "ab"}, {"a": "ba"}]},
+      "result": [
+        {"a": "ab"}
+      ]
+    },
+    {
+      "name": "type mismatch, value type and logical type",
+      "selector": "$[?length(@.a==@.b)>2]",
+      "invalid_selector": true
+    }
+  ]
+}


### PR DESCRIPTION
These additional test cases don't make a lot of real world sense, but short of defining one or more non-standard function extensions specifically for testing, it's the best I could come up with.

Relevant grammar:

```plain
function-expr       = function-name "(" S [function-argument
                         *(S "," S function-argument)] S ")"
function-argument   = literal /
                      filter-query / ; (includes singular-query)
                      logical-expr /
                      function-expr

logical-expr        = logical-or-expr
logical-or-expr     = logical-and-expr *(S "||" S logical-and-expr)
                        ; disjunction
                        ; binds less tightly than conjunction
logical-and-expr    = basic-expr *(S "&&" S basic-expr)
                        ; conjunction
                        ; binds more tightly than disjunction

basic-expr          = paren-expr /
                      comparison-expr /
                      test-expr

paren-expr          = [logical-not-op S] "(" S logical-expr S ")"
                                        ; parenthesized expression
```