### PR TITLE
Cover function expressions as function parameters

### DIFF
--- a/cts.json
+++ b/cts.json
@@ -2398,6 +2398,32 @@
       ]
     },
     {
+      "name": "filter, equals, special nothing",
+      "selector": "$.values[?length(@.a) == value($..c)]",
+      "document": {
+        "c": "cd",
+        "values": [
+          {
+            "a": "ab"
+          },
+          {
+            "c": "d"
+          },
+          {
+            "a": null
+          }
+        ]
+      },
+      "result": [
+        {
+          "c": "d"
+        },
+        {
+          "a": null
+        }
+      ]
+    },
+    {
       "name": "index selector, first element",
       "selector": "$[0]",
       "document": [
@@ -4104,6 +4130,26 @@
           }
         ]
       },
+      "result": [
+        {
+          "a": "ab"
+        }
+      ]
+    },
+    {
+      "name": "functions, length, arg is special nothing",
+      "selector": "$[?length(value(@.a))>0]",
+      "document": [
+        {
+          "a": "ab"
+        },
+        {
+          "c": "d"
+        },
+        {
+          "a": null
+        }
+      ],
       "result": [
         {
           "a": "ab"

--- a/cts.json
+++ b/cts.json
@@ -4086,6 +4086,31 @@
       "invalid_selector": true
     },
     {
+      "name": "functions, length, non-singular query arg",
+      "selector": "$[?length(@.*)<3]",
+      "invalid_selector": true
+    },
+    {
+      "name": "functions, length, arg is a function expression",
+      "selector": "$.values[?length(@.a)==length(value($..c))]",
+      "document": {
+        "c": "cd",
+        "values": [
+          {
+            "a": "ab"
+          },
+          {
+            "a": "d"
+          }
+        ]
+      },
+      "result": [
+        {
+          "a": "ab"
+        }
+      ]
+    },
+    {
       "name": "functions, match, found match",
       "selector": "$[?match(@.a, 'a.*')]",
       "document": [
@@ -4249,6 +4274,26 @@
       "name": "functions, match, too many params",
       "selector": "$[?match(@.a,@.b,@.c)==1]",
       "invalid_selector": true
+    },
+    {
+      "name": "functions, match, arg is a function expression",
+      "selector": "$.values[?match(@.a, value($..['regex']))]",
+      "document": {
+        "regex": "a.*",
+        "values": [
+          {
+            "a": "ab"
+          },
+          {
+            "a": "ba"
+          }
+        ]
+      },
+      "result": [
+        {
+          "a": "ab"
+        }
+      ]
     },
     {
       "name": "functions, search, at the end",
@@ -4445,6 +4490,29 @@
       "name": "functions, search, too many params",
       "selector": "$[?search(@.a,@.b,@.c)]",
       "invalid_selector": true
+    },
+    {
+      "name": "functions, search, arg is a function expression",
+      "selector": "$.values[?search(@, value($..['regex']))]",
+      "document": {
+        "regex": "b.?b",
+        "values": [
+          "abc",
+          "bcd",
+          "bab",
+          "bba",
+          "bbab",
+          "b",
+          true,
+          [],
+          {}
+        ]
+      },
+      "result": [
+        "bab",
+        "bba",
+        "bbab"
+      ]
     },
     {
       "name": "functions, value, single-value nodelist",

--- a/tests/filter.json
+++ b/tests/filter.json
@@ -770,6 +770,22 @@
       "result": [
         {"a": 0.011, "d": "e"}
       ]
+    },
+    {
+      "name": "equals, special nothing",
+      "selector" : "$.values[?length(@.a) == value($..c)]",
+      "document" : {
+        "c": "cd",
+        "values": [
+          {"a": "ab"},
+          {"c": "d"},
+          {"a": null}
+        ]
+      },
+      "result": [
+        {"c": "d"},
+        {"a": null}
+      ]
     }
   ]
 }

--- a/tests/functions/length.json
+++ b/tests/functions/length.json
@@ -66,6 +66,22 @@
       "name": "too many params",
       "selector" : "$[?length(@.a,@.b)==1]",
       "invalid_selector": true
+    },
+    {
+      "name": "non-singular query arg",
+      "selector": "$[?length(@.*)<3]",
+      "invalid_selector": true
+    },
+    {
+      "name": "arg is a function expression",
+      "selector" : "$.values[?length(@.a)==length(value($..c))]",
+      "document" : {
+        "c": "cd",
+        "values": [{"a": "ab"}, {"a": "d"}]
+      },
+      "result": [
+        {"a": "ab"}
+      ]
     }
   ]
 }

--- a/tests/functions/length.json
+++ b/tests/functions/length.json
@@ -82,6 +82,18 @@
       "result": [
         {"a": "ab"}
       ]
+    },
+    {
+      "name": "arg is special nothing",
+      "selector" : "$[?length(value(@.a))>0]",
+      "document" : [
+          {"a": "ab"},
+          {"c": "d"},
+          {"a": null}
+      ],
+      "result": [
+        {"a": "ab"}
+      ]
     }
   ]
 }

--- a/tests/functions/match.json
+++ b/tests/functions/match.json
@@ -85,6 +85,26 @@
       "name": "too many params",
       "selector" : "$[?match(@.a,@.b,@.c)==1]",
       "invalid_selector": true
+    },
+    {
+      "name": "arg is a function expression",
+      "selector": "$.values[?match(@.a, value($..['regex']))]",
+      "document": {
+        "regex": "a.*",
+        "values": [
+          {
+            "a": "ab"
+          },
+          {
+            "a": "ba"
+          }
+        ]
+      },
+      "result": [
+        {
+          "a": "ab"
+        }
+      ]
     }
   ]
 }

--- a/tests/functions/search.json
+++ b/tests/functions/search.json
@@ -100,6 +100,25 @@
       "name": "too many params",
       "selector" : "$[?search(@.a,@.b,@.c)]",
       "invalid_selector": true
+    },
+    {
+      "name": "arg is a function expression",
+      "selector" : "$.values[?search(@, value($..['regex']))]",
+      "document" : {
+        "regex": "b.?b",
+        "values": [
+          "abc",
+          "bcd",
+          "bab",
+          "bba",
+          "bbab",
+          "b",
+          true,
+          [],
+          {}
+        ]
+      },
+      "result": ["bab", "bba", "bbab"]
     }
   ]
 }


### PR DESCRIPTION
These additional test cases cover using function expressions as function parameters, plus an additional `length()` case [mentioned in the spec](https://datatracker.ietf.org/doc/html/draft-ietf-jsonpath-base-21#name-examples-7).

Note that it's not currently possible to test `count()` and `value()` with function expressions as parameters using standard function extensions alone. None of the standard function extensions return a _NodesType_.

This PR partially replaces #51. See also the conversation on PR #51.