### PR TITLE
Add tests for incorrect filter usage

### DIFF
--- a/cts.json
+++ b/cts.json
@@ -510,6 +510,26 @@
       ]
     },
     {
+      "name": "filter, existence without selector",
+      "selector": "$[?@]",
+      "document": {
+        "a": {},
+        "b": 1
+      },
+      "result": [
+        {},
+        1
+      ]
+    },
+    {
+      "name": "filter, existence test on primitive (not supported)",
+      "selector": "$.a[?@]",
+      "document": {
+        "a": 1
+      },
+      "result": []
+    },
+    {
       "name": "filter, equals string, single quotes",
       "selector": "$[?@.a=='b']",
       "document": [
@@ -1843,6 +1863,43 @@
           42
         ]
       ]
+    },
+    {
+      "name": "filter, on primitive (not supported)",
+      "selector": "$.a[?@ == 1]",
+      "document": {
+        "a": 1
+      },
+      "result": []
+    },
+    {
+      "name": "filter, on primitive object member value (@ refers to member values, not the object)",
+      "selector": "$[?@.a == 1]",
+      "document": {
+        "a": 1
+      },
+      "result": []
+    },
+    {
+      "name": "filter, name selector on array",
+      "selector": "$[?@[\"0\"] == 5]",
+      "document": [
+        [
+          5,
+          6
+        ]
+      ],
+      "result": []
+    },
+    {
+      "name": "filter, index selector on object",
+      "selector": "$[?@[0] == 5]",
+      "document": [
+        {
+          "0": 5
+        }
+      ],
+      "result": []
     },
     {
       "name": "filter, relative non-singular query, index, equal",
@@ -4094,6 +4151,22 @@
           "d": "f"
         }
       ],
+      "result": []
+    },
+    {
+      "name": "functions, length, filter on primitive array element (@ refers to array elements, not the array)",
+      "selector": "$[?length(@)==1]",
+      "document": [
+        1
+      ],
+      "result": []
+    },
+    {
+      "name": "functions, length, filter on primitive object member value (@ refers to member values, not the object)",
+      "selector": "$[?length(@)==1]",
+      "document": {
+        "a": 1
+      },
       "result": []
     },
     {

--- a/tests/filter.json
+++ b/tests/filter.json
@@ -17,6 +17,18 @@
       ]
     },
     {
+      "name": "existence without selector",
+      "selector": "$[?@]",
+      "document": {"a": {}, "b": 1},
+      "result": [{}, 1]
+    },
+    {
+      "name": "existence test on primitive (not supported)",
+      "selector": "$.a[?@]",
+      "document": {"a": 1},
+      "result": []
+    },
+    {
       "name": "equals string, single quotes",
       "selector" : "$[?@.a=='b']",
       "document" : [{"a": "b", "d": "e"}, {"a":"c", "d": "f"}],
@@ -477,6 +489,30 @@
         [0, 1, 2],
         [42]
       ]
+    },
+    {
+      "name": "on primitive (not supported)",
+      "selector": "$.a[?@ == 1]",
+      "document": {"a": 1},
+      "result": []
+    },
+    {
+      "name": "on primitive object member value (@ refers to member values, not the object)",
+      "selector": "$[?@.a == 1]",
+      "document": {"a": 1},
+      "result": []
+    },
+    {
+      "name": "name selector on array",
+      "selector": "$[?@[\"0\"] == 5]",
+      "document": [[5, 6]],
+      "result": []
+    },
+    {
+      "name": "index selector on object",
+      "selector": "$[?@[0] == 5]",
+      "document": [{"0": 5}],
+      "result": []
     },
     {
       "name": "relative non-singular query, index, equal",

--- a/tests/functions/length.json
+++ b/tests/functions/length.json
@@ -53,6 +53,18 @@
       "result": []
     },
     {
+      "name": "filter on primitive array element (@ refers to array elements, not the array)",
+      "selector": "$[?length(@)==1]",
+      "document": [1],
+      "result": []
+    },
+    {
+      "name": "filter on primitive object member value (@ refers to member values, not the object)",
+      "selector": "$[?length(@)==1]",
+      "document": {"a": 1},
+      "result": []
+    },
+    {
       "name": "result must be compared",
       "selector" : "$[?length(@.a)]",
       "invalid_selector": true


### PR DESCRIPTION
This mainly covers using filter on primitives, which should have no result, see [RFC 9535 section 2.3.5.2](https://www.rfc-editor.org/rfc/rfc9535#name-semantics-7):
> The filter selector works with arrays and objects exclusively. [...] Applied to a primitive value, it selects nothing

(This was inspired by https://github.com/hiltontj/serde_json_path/issues/49; CC @hiltontj)

Please let me know if any of the tests are incorrect, or if I should adjust them or split this into separate pull requests. Any feedback is appreciated!