### PR TITLE
Add GitHub workflow for updating `cts.json`

### DIFF
--- a/.github/workflows/build_cts_json.yaml
+++ b/.github/workflows/build_cts_json.yaml
@@ -43,8 +43,8 @@ jobs:
     # Important: The push event will not trigger any other workflows, see
     # https://github.com/stefanzweifel/git-auto-commit-action?tab=readme-ov-file#commits-made-by-this-action-do-not-trigger-new-workflow-runs
     - name: Commit & push changes
-      # Only run for push events (on `main` branch); don't run for pull requests
-      if: github.event_name == 'push'
+      # Only run for push events on `main` branch
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: stefanzweifel/git-auto-commit-action@v5
       with:
         commit_message: 'Update `cts.json`'

--- a/.github/workflows/build_cts_json.yaml
+++ b/.github/workflows/build_cts_json.yaml
@@ -1,15 +1,18 @@
-name: Update 'cts.json'
+name: Build 'cts.json'
 on:
   push:
     branches:
       - main
+  pull_request:
 
 jobs:
-  update-cts:
+  build-cts:
     runs-on: ubuntu-latest
 
     permissions:
       # Allow the job to push the changed file to the repository
+      # For pull requests from forks this seems to be implicitly changed to 'read', as desired, see
+      # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#how-the-permissions-are-calculated-for-a-workflow-job
       contents: write
 
     steps:
@@ -19,7 +22,7 @@ jobs:
       id: setup-node
       uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 'lts/*'
 
     - name: Run build
       run: ./build.sh
@@ -40,6 +43,8 @@ jobs:
     # Important: The push event will not trigger any other workflows, see
     # https://github.com/stefanzweifel/git-auto-commit-action?tab=readme-ov-file#commits-made-by-this-action-do-not-trigger-new-workflow-runs
     - name: Commit & push changes
+      # Only run for push events (on `main` branch); don't run for pull requests
+      if: github.event_name == 'push'
       uses: stefanzweifel/git-auto-commit-action@v5
       with:
         commit_message: 'Update `cts.json`'

--- a/.github/workflows/update-cts-json.yaml
+++ b/.github/workflows/update-cts-json.yaml
@@ -1,0 +1,46 @@
+name: Update 'cts.json'
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-cts:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Allow the job to push the changed file to the repository
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      id: setup-node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+
+    - name: Run build
+      run: ./build.sh
+
+    # To be safe, verify that either there are no changes or only `cts.json` has changed
+    - name: Verify no unexpected changes
+      run: |
+        # Check for changes to any file other than `cts.json`,
+        # see https://stackoverflow.com/a/29374503
+        # Note that this does not detect new untracked files
+        if ! git diff --exit-code --quiet -- . ':!cts.json'; then
+          echo "Unexpected changes:"
+          git diff -- . ':!cts.json'
+          exit 1
+        fi
+
+    # Commit and push changes; has no effect if the file did not change
+    # Important: The push event will not trigger any other workflows, see
+    # https://github.com/stefanzweifel/git-auto-commit-action?tab=readme-ov-file#commits-made-by-this-action-do-not-trigger-new-workflow-runs
+    - name: Commit & push changes
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        commit_message: 'Update `cts.json`'
+        file_pattern: 'cts.json'

--- a/.github/workflows/validate_json_schema.yaml
+++ b/.github/workflows/validate_json_schema.yaml
@@ -6,7 +6,7 @@ jobs:
   verify-json-validation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Validate CTS against JSON Schema
         uses: cardinalby/schema-validator-action@v2
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,3 @@
-
-
 # Contributing to jsonpath-compliance-test-suite
 
 The jsonpath-compliance-test-suite project team welcomes contributions from the community.
@@ -29,7 +27,8 @@ You need to have [Node.js](https://nodejs.org/en/) (v18 or higher) installed to 
 
 To add or modify tests:
 - add/edit the corresponding file(s) in the `tests` directory
-- run the `build.sh` script located in the root folder
+- [optional] run the `build.sh` or `build.ps1` script located in the root folder\
+  (this will be performed automatically by GitHub CI after the pull request has been merged to `main`)
 - commit the changes to `tests` and `cts.json`
 
 Do not modify `cts.json` directly!
@@ -73,7 +72,7 @@ notification when you git push.
 
 ### Formatting Commit Messages
 
-We follow the conventions on [How to Write a Git Commit Message](http://chris.beams.io/posts/git-commit/).
+We follow the conventions on [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/).
 
 Be sure to include any related GitHub issue references in the commit message.  See
 [GFM syntax](https://guides.github.com/features/mastering-markdown/#GitHub-flavored-markdown) for referencing issues


### PR DESCRIPTION
Resolves #33

For every push to `main` the new workflow runs `build.sh` and afterwards commits & pushes the changes for `cts.json`, if any.

Example workflow runs:
- [No change](https://github.com/Marcono1234/jsonpath-compliance-test-suite/actions/runs/8052973356)
- [Change](https://github.com/Marcono1234/jsonpath-compliance-test-suite/actions/runs/8052985119) and commit https://github.com/Marcono1234/jsonpath-compliance-test-suite/commit/b01ffbb6ad4f3c9f24d1a4bcf0be2ff168905415
- [Change & unexpected change](https://github.com/Marcono1234/jsonpath-compliance-test-suite/actions/runs/8053015649)

Limitations:
- The push event for updating `cts.json` does not trigger any other workflows, see [action documentation](https://github.com/stefanzweifel/git-auto-commit-action/tree/master?tab=readme-ov-file#commits-made-by-this-action-do-not-trigger-new-workflow-runs)
- This might need additional configuration if `main` is a protected branch, see [action documentation](https://github.com/stefanzweifel/git-auto-commit-action/tree/master?tab=readme-ov-file#push-to-protected-branches)
(might depend on who is the "actor" triggering the workflow; so maybe if a member who is allowed to push to protected branches merged the pull request to `main`, then it works without additional configuration?)

Feedback is appreciated!