### PR TITLE
Enable type checking in `build.js` (for IDE)

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 const fs = require('fs');
 const path = require('path');
 /**


### PR DESCRIPTION
See https://www.typescriptlang.org/docs/handbook/intro-to-js-ts.html#ts-check

In VS Code this seems to automatically perform type checking then when viewing and editing the file. But this has no effect when using `build.sh` even when there are type errors, and is not checked by GitHub CI.

No worries if you don't want to include this change.