### PR TITLE
Introduce some tests of non-determinism

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ Many editors support that file natively. Others (such as VS code) require a plug
 To add or modify a test suite, edit the corresponding file in the `tests` directory.
 To generate `cts.json`, run the `build.sh` located in the root folder. Do not modify `cts.json` directly.
 More details are available in the [Contributor Guide](./CONTRIBUTING.md).
+
+### Non-determinism
+
+Where the spec allows non-deterministic results for a given testcase, the testcase should specify an array of all the valid results (each of which is itself an array representing the resultant nodelist from the query) in the "results" member (and should not specify a "result" member).

--- a/cts.json
+++ b/cts.json
@@ -93,9 +93,15 @@
         "a": "A",
         "b": "B"
       },
-      "result": [
-        "A",
-        "B"
+      "results": [
+        [
+          "A",
+          "B"
+        ],
+        [
+          "B",
+          "A"
+        ]
       ]
     },
     {
@@ -135,9 +141,15 @@
           "b": "By"
         }
       },
-      "result": [
-        "Ax",
-        "Ay"
+      "results": [
+        [
+          "Ax",
+          "Ay"
+        ],
+        [
+          "Ay",
+          "Ax"
+        ]
       ]
     },
     {
@@ -462,6 +474,34 @@
         "e",
         "c",
         "f"
+      ]
+    },
+    {
+      "name": "basic, descendant segment, object traversal, multiple selectors",
+      "selector": "$..['a','d']",
+      "document": {
+        "x": {
+          "a": "b",
+          "d": "e"
+        },
+        "y": {
+          "a": "c",
+          "d": "f"
+        }
+      },
+      "results": [
+        [
+          "b",
+          "e",
+          "c",
+          "f"
+        ],
+        [
+          "c",
+          "f",
+          "b",
+          "e"
+        ]
       ]
     },
     {

--- a/cts.schema.json
+++ b/cts.schema.json
@@ -66,7 +66,6 @@
         },
         {
           "required": [
-            "name",
             "invalid_selector"
           ],
           "properties": {

--- a/cts.schema.json
+++ b/cts.schema.json
@@ -74,6 +74,8 @@
     },
     "test_case_results": {
       "type": "array",
+      "items": {"$ref": "#/$defs/test_case_result"},
+      "minItems": 2,
       "description": "An array of possible expected results of applying the selector to the document, each element of which contains all the matched values"
     },
     "selector": {

--- a/cts.schema.json
+++ b/cts.schema.json
@@ -50,6 +50,7 @@
             "result"
           ],
           "properties": {
+            "invalid_selector": false,
             "results": false
           }
         },
@@ -59,13 +60,20 @@
             "results"
           ],
           "properties": {
+            "invalid_selector": false,
             "result": false
           }
         },
         {
           "required": [
+            "name",
             "invalid_selector"
-          ]
+          ],
+          "properties": {
+            "document": false,
+            "result": false,
+            "results": false
+          }
         }
       ]
     },

--- a/cts.schema.json
+++ b/cts.schema.json
@@ -48,13 +48,19 @@
           "required": [
             "document",
             "result"
-          ]
+          ],
+          "properties": {
+            "results": false
+          }
         },
         {
           "required": [
             "document",
             "results"
-          ]
+          ],
+          "properties": {
+            "result": false
+          }
         },
         {
           "required": [

--- a/cts.schema.json
+++ b/cts.schema.json
@@ -32,6 +32,9 @@
         "result": {
           "$ref": "#/$defs/test_case_result"
         },
+        "results": {
+          "$ref": "#/$defs/test_case_results"
+        },
         "invalid_selector": {
           "$ref": "#/$defs/invalid_selector"
         }
@@ -62,6 +65,10 @@
     "test_case_result": {
       "type": "array",
       "description": "The expected result of applying the selector to the document, contains all the matched values"
+    },
+    "test_case_results": {
+      "type": "array",
+      "description": "An array of possible expected results of applying the selector to the document, each element of which contains all the matched values"
     },
     "selector": {
       "description": "The JSONPath selector",

--- a/cts.schema.json
+++ b/cts.schema.json
@@ -52,6 +52,12 @@
         },
         {
           "required": [
+            "document",
+            "results"
+          ]
+        },
+        {
+          "required": [
             "invalid_selector"
           ]
         }

--- a/tests/basic.json
+++ b/tests/basic.json
@@ -92,10 +92,13 @@
         "a": "A",
         "b": "B"
       },
-      "result": [
+      "results": [[
         "A",
         "B"
-      ]
+      ],[
+        "B",
+        "A"
+      ]]
     },
     {
       "name": "wildcard shorthand, array data",
@@ -134,10 +137,13 @@
           "b": "By"
         }
       },
-      "result": [
+      "results": [[
         "Ax",
         "Ay"
-      ]
+      ],[
+        "Ay",
+        "Ax"
+      ]]
     },
     {
       "name": "multiple selectors",
@@ -423,6 +429,22 @@
         "c",
         "f"
       ]
+    },
+    {
+      "name": "descendant segment, object traversal, multiple selectors",
+      "selector" : "$..['a','d']",
+      "document" : {"x": {"a": "b", "d": "e"}, "y": {"a":"c", "d": "f"}},
+      "results": [[
+        "b",
+        "e",
+        "c",
+        "f"
+      ],[
+        "c",
+        "f",
+        "b",
+        "e"
+      ]]
     },
     {
       "name": "bald descendant segment",


### PR DESCRIPTION
This is not necessarily an exhaustive set of tests of the non-deterministic features of RFC 9535. However, it establishes a convention for how to write such tests.

A non-deterministic test has a "results" key instead of a "result" key. The value corresponding to "results" is an array or possible results. If an implementation produces any one of these, the test should pass. If an implementation produces any other result, the test should fail.

Ref https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/issues/9