### PR TITLE
Test that `&&` binds more tightly than `||`

### DIFF
--- a/tests/filter.json
+++ b/tests/filter.json
@@ -799,6 +799,44 @@
         [1, 2],
         [2, 1]
       ]
+    },
+    {
+      "name": "and binds more tightly than or",
+      "selector" : "$[?@.a || @.b && @.b]",
+      "document" : [{"a": 1}],
+      "result": [
+        {"a": 1}
+      ]
+    },
+    {
+      "name": "left to right evaluation",
+      "selector" : "$[?@.b && @.b || @.a]",
+      "document" : [{"a": 1}],
+      "result": [
+        {"a": 1}
+      ]
+    },
+    {
+      "name": "group terms, left",
+      "selector" : "$[?(@.a || @.b) && @.a]",
+      "document" : [{"a": 1}],
+      "result": [
+        {"a": 1}
+      ]
+    },
+    {
+      "name": "group terms, right",
+      "selector" : "$[?@.a && (@.b || @.a)]",
+      "document" : [{"a": 1}],
+      "result": [
+        {"a": 1}
+      ]
+    },
+    {
+      "name": "group terms, or before and",
+      "selector" : "$[?(@.a || @.b) && @.b]",
+      "document" : [{"a": 1}],
+      "result": []
     }
   ]
 }


### PR DESCRIPTION
Test that `&&` binds more tightly than `||`.

`$[?@.a || @.b && @.b]` is testing that `true || false && false` is equivalent to `(true || (false && false))`, which should evaluate to `true`.

`$[?@.b && @.b || @.a]` is testing that `false && false || true` is equivalent to `((false && false ) || true)`, which should evaluate to `true`. This should catch implementations that are inadvertently evaluating from right to left with equal precedence.

I had initially wanted to do `$[?true || false && false]`, but realised literal `true` and `false` are not a "basic-expr". So went with existence tests instead of `$[?true == true || false == false && false == false]`.