### PR TITLE
Cover existence tests in logical expressions

### DIFF
--- a/tests/filter.json
+++ b/tests/filter.json
@@ -408,6 +408,23 @@
       ]
     },
     {
+      "name": "exists and exists, data false",
+      "selector" : "$[?@.a&&@.b]",
+      "document" : [{"a": false, "b": false}, {"b": false}, {"c": false}],
+      "result": [
+        {"a": false, "b": false}
+      ]
+    },
+    {
+      "name": "exists or exists, data false",
+      "selector" : "$[?@.a||@.b]",
+      "document" : [{"a": false, "b": false}, {"b": false}, {"c": false}],
+      "result": [
+        {"a": false, "b": false},
+        {"b": false}
+      ]
+    },
+    {
       "name": "and",
       "selector" : "$[?@.a>0&&@.a<10]",
       "document" : [{"a": -10, "d": "e"}, {"a":5, "d": "f"}, {"a":20, "d": "f"}],


### PR DESCRIPTION
Test that singular filter queries are evaluated as existence tests when they are part of a logical expression, but not involving a comparison expression.

This was [a bug](https://github.com/jg-rp/python-jsonpath/issues/57) for me. I was eagerly unwrapping singular node lists before evaluating comparison expression **and** logical expressions.

