### PR TITLE
Add a non-deterministic test not involving objects

### DIFF
--- a/tests/basic.json
+++ b/tests/basic.json
@@ -401,6 +401,15 @@
       ]
     },
     {
+      "name": "descendant segment, wildcard selector, nested arrays",
+      "selector" : "$..[*]",
+      "document" : [[[1]],[2]],
+      "results": [
+        [[[1]],[2],[1],1,2],
+        [[[1]],[2],[1],2,1]
+      ]
+    },
+    {
       "name": "descendant segment, wildcard shorthand, object data",
       "selector" : "$..*",
       "document" : {"a": "b"},


### PR DESCRIPTION
The non-determinism in this case arises because of the interleaving of descendants allowed by RFC 9535 Section 2.5.2.2.

Note that there is more non-determinism in the ordering of descendants, but much of this is removed by the applications of the child wildcard ([*]).

The list of the input node and its descendants (the result of .. before [*] is applied) can be in any of these orders:

[[[[1]],[2]],[[1]],[1],[2],1,2]
[[[[1]],[2]],[[1]],[1],[2],2,1]
[[[[1]],[2]],[[1]],[1],1,[2],2]
[[[[1]],[2]],[[1]],[2],[1],1,2]
[[[[1]],[2]],[[1]],[2],[1],2,1]
[[[[1]],[2]],[[1]],[2],2,[1],1]

Notice that these all satisfy the rules in Section 2.5.2.2:

* nodes of any array are visited in array order, and
* nodes are visited before their descendants.

Ref: https://github.com/glyn/jsonpath-nondeterminism

/cc @gregsdennis @jg-rp @f3ath @hiltontj who were involved in the initial discussion of non-deterministic tests.