### PR TITLE
Add a nested object case with non-determinism

### DIFF
--- a/cts.json
+++ b/cts.json
@@ -478,6 +478,112 @@
       ]
     },
     {
+      "name": "basic, descendant segment, wildcard selector, nested objects",
+      "selector": "$..[*]",
+      "document": {
+        "a": {
+          "c": {
+            "e": 1
+          }
+        },
+        "b": {
+          "d": 2
+        }
+      },
+      "results": [
+        [
+          {
+            "c": {
+              "e": 1
+            }
+          },
+          {
+            "d": 2
+          },
+          {
+            "e": 1
+          },
+          1,
+          2
+        ],
+        [
+          {
+            "c": {
+              "e": 1
+            }
+          },
+          {
+            "d": 2
+          },
+          {
+            "e": 1
+          },
+          2,
+          1
+        ],
+        [
+          {
+            "c": {
+              "e": 1
+            }
+          },
+          {
+            "d": 2
+          },
+          2,
+          {
+            "e": 1
+          },
+          1
+        ],
+        [
+          {
+            "d": 2
+          },
+          {
+            "c": {
+              "e": 1
+            }
+          },
+          {
+            "e": 1
+          },
+          1,
+          2
+        ],
+        [
+          {
+            "d": 2
+          },
+          {
+            "c": {
+              "e": 1
+            }
+          },
+          {
+            "e": 1
+          },
+          2,
+          1
+        ],
+        [
+          {
+            "d": 2
+          },
+          {
+            "c": {
+              "e": 1
+            }
+          },
+          2,
+          {
+            "e": 1
+          },
+          1
+        ]
+      ]
+    },
+    {
       "name": "basic, descendant segment, wildcard shorthand, object data",
       "selector": "$..*",
       "document": {

--- a/tests/basic.json
+++ b/tests/basic.json
@@ -410,6 +410,19 @@
       ]
     },
     {
+      "name": "descendant segment, wildcard selector, nested objects",
+      "selector" : "$..[*]",
+      "document" : {"a": {"c": {"e": 1}}, "b": {"d": 2}},
+      "results": [
+        [{"c": {"e": 1}}, {"d": 2}, {"e": 1}, 1, 2],
+        [{"c": {"e": 1}}, {"d": 2}, {"e": 1}, 2, 1],
+        [{"c": {"e": 1}}, {"d": 2}, 2, {"e": 1}, 1],
+        [{"d": 2}, {"c": {"e": 1}}, {"e": 1}, 1, 2],
+        [{"d": 2}, {"c": {"e": 1}}, {"e": 1}, 2, 1],
+        [{"d": 2}, {"c": {"e": 1}}, 2, {"e": 1}, 1]
+      ]
+    },
+    {
       "name": "descendant segment, wildcard shorthand, object data",
       "selector" : "$..*",
       "document" : {"a": "b"},


### PR DESCRIPTION
The non-determinism comes from the descendant traversal ordering rules as well as from the unordered nature of objects.

(Please note that this was accidentally pushed to main earlier and then reverted. A branch protection rule is now in place!)