### PR TITLE
Add filter test for equality with self

### DIFF
--- a/tests/filter.json
+++ b/tests/filter.json
@@ -88,6 +88,18 @@
       ]
     },
     {
+      "name": "equals self",
+      "selector" : "$[?@==@]",
+      "document" : [1, null, true, {"a": "b"}, [false]],
+      "result": [
+        1,
+        null,
+        true,
+        {"a": "b"},
+        [false]
+      ]
+    },
+    {
       "name": "deep equality, arrays",
       "selector" : "$[?@.a==@.b]",
       "document" : [


### PR DESCRIPTION
It looks like the case `@==@` was previously not covered, but is mentioned in the RFC (as `$.a[?@ == @]`), so I thought it might be good to add it.

Please let me know what you think.