### PR TITLE
Add filter tests for valid non-singular segment

### DIFF
--- a/tests/filter.json
+++ b/tests/filter.json
@@ -467,6 +467,45 @@
       ]
     },
     {
+      "name": "non-singular existence, wildcard",
+      "selector" : "$[?@.*]",
+      "document" : [1, [], [2], {}, {"a": 3}],
+      "result": [
+        [2],
+        {"a": 3}
+      ]
+    },
+    {
+      "name": "non-singular existence, multiple",
+      "selector" : "$[?@[0, 0, 'a']]",
+      "document" : [1, [], [2], [2, 3], {"a": 3}, {"b": 4}, {"a": 3, "b": 4}],
+      "result": [
+        [2],
+        [2, 3],
+        {"a": 3},
+        {"a": 3, "b": 4}
+      ]
+    },
+    {
+      "name": "non-singular existence, slice",
+      "selector" : "$[?@[0:2]]",
+      "document" : [1, [], [2], [2, 3, 4], {}, {"a": 3}],
+      "result": [
+        [2],
+        [2, 3, 4]
+      ]
+    },
+    {
+      "name": "non-singular existence, negated",
+      "selector" : "$[?!@.*]",
+      "document" : [1, [], [2], {}, {"a": 3}],
+      "result": [
+        1,
+        [],
+        {}
+      ]
+    },
+    {
       "name": "non-singular query in comparison, slice",
       "selector" : "$[?@[0:0]==0]",
       "invalid_selector": true


### PR DESCRIPTION
Unless I have overlooked something, the existing tests (code in the lines below my changes) was only covering invalid non-singular filters.

These tests also make sure that for example
- `?@[0, 0, 'a']` does not cause the result to contain duplicate values (despite the duplicate `0`)
- a slice such as `?@[0:2]` does not truncate the result if the array has more elements
