### PR TITLE
Add tests for invalid surrogate pairs

### DIFF
--- a/tests/name_selector.json
+++ b/tests/name_selector.json
@@ -200,6 +200,16 @@
       ]
     },
     {
+      "name": "double quotes, supplementary plane character",
+      "selector": "$[\"𝄞\"]",
+      "document": {
+        "𝄞": "A"
+      },
+      "result": [
+        "A"
+      ]
+    },
+    {
       "name": "double quotes, escaped double quote",
       "selector": "$[\"\\\"\"]",
       "document": {
@@ -402,6 +412,31 @@
     {
       "name": "double quotes, unicode escape brackets long",
       "selector": "$[\"\\u{10ffff}\"]",
+      "invalid_selector": true
+    },
+    {
+      "name": "double quotes, single high surrogate",
+      "selector": "$[\"\\uD800\"]",
+      "invalid_selector": true
+    },
+    {
+      "name": "double quotes, single low surrogate",
+      "selector": "$[\"\\uDC00\"]",
+      "invalid_selector": true
+    },
+    {
+      "name": "double quotes, high high surrogate",
+      "selector": "$[\"\\uD800\\uD800\"]",
+      "invalid_selector": true
+    },
+    {
+      "name": "double quotes, low low surrogate",
+      "selector": "$[\"\\uDC00\\uDC00\"]",
+      "invalid_selector": true
+    },
+    {
+      "name": "double quotes, surrogate non-surrogate",
+      "selector": "$[\"\\uD800\\u1234\"]",
       "invalid_selector": true
     },
     {


### PR DESCRIPTION
Adds tests for invalid surrogate pairs, and one test for directly using a character > U+FFFF (`𝄞`) in the selector, instead of escaping it.

----
Note: Another interesting test would be
- escaped + non-escaped surrogate character, for example: `"selector": "$[\"\\uD800\uDC00\"]"`
(for this a JSONPath implementation might erroneously first convert `\\uD800` to U+D800 before performing validation, and then consider this a valid surrogate pair)
- malformed non-escaped surrogate pairs, for example `"selector": "$[\"\uD800\uD800\"]"`

Note in both cases the single `\` instead of `\\`.

Both are not permitted by JSONPath because it says the query must be valid UTF-8, which is not the case here.

However, it depends on the programming language whether such malformed surrogate pairs are possible. For example for Java whose strings are UTF-16 based such selectors would be valid strings, but the JSONPath implementation would have to reject them.

The problem is that for other programming languages such strings are not valid (e.g. Rust uses UTF-8 for strings), so including for example `"selector": "$[\"\\uD800\uDC00\"]"` might prevent a Rust library from loading `cts.json` at all. Therefore such tests can probably not be added.