### PR TITLE
Add test for non-escaped U+007F (DEL control character)

### DIFF
--- a/tests/name_selector.json
+++ b/tests/name_selector.json
@@ -200,6 +200,16 @@
       ]
     },
     {
+      "name": "double quotes, embedded U+007F",
+      "selector": "$[\"\u007F\"]",
+      "document": {
+        "\u007F": "A"
+      },
+      "result": [
+        "A"
+      ]
+    },
+    {
       "name": "double quotes, supplementary plane character",
       "selector": "$[\"𝄞\"]",
       "document": {


### PR DESCRIPTION
The JSONPath specification says only the control characters 0x00 to 0x1F must be escaped (same as for JSON). The control character 0x7F (DEL) does not have to be escaped.

However, some JSON libraries are too strict and reject a non-escaped 0x7F, see also https://github.com/nst/JSONTestSuite/issues/118.
Therefore this test makes sure JSONPath implementations don't make the same error.