### PR TITLE
Add tests for invalid and uncommon filter literal values

### DIFF
--- a/tests/filter.json
+++ b/tests/filter.json
@@ -846,7 +846,31 @@
       ]
     },
     {
-      "name": "equals number, exponent leading 0",
+      "name": "equals number, exponent 0",
+      "selector" : "$[?@.a==1e0]",
+      "document" : [{"a": 1, "d": "e"}, {"a":2, "d": "f"}, {"a":"1", "d": "g"}],
+      "result": [
+        {"a": 1, "d": "e"}
+      ]
+    },
+    {
+      "name": "equals number, exponent -0",
+      "selector" : "$[?@.a==1e-0]",
+      "document" : [{"a": 1, "d": "e"}, {"a":2, "d": "f"}, {"a":"1", "d": "g"}],
+      "result": [
+        {"a": 1, "d": "e"}
+      ]
+    },
+    {
+      "name": "equals number, exponent +0",
+      "selector" : "$[?@.a==1e+0]",
+      "document" : [{"a": 1, "d": "e"}, {"a":2, "d": "f"}, {"a":"1", "d": "g"}],
+      "result": [
+        {"a": 1, "d": "e"}
+      ]
+    },
+    {
+      "name": "equals number, exponent leading -0",
       "selector" : "$[?@.a==1e-02]",
       "document" : [{"a": 0.01, "d": "e"}, {"a":0.02, "d": "f"}, {"a":"0.01", "d": "g"}],
       "result": [
@@ -854,7 +878,7 @@
       ]
     },
     {
-      "name": "equals number, exponent 00",
+      "name": "equals number, exponent +00",
       "selector" : "$[?@.a==1e+00]",
       "document" : [{"a": 1, "d": "e"}, {"a":2, "d": "f"}, {"a":"1", "d": "g"}],
       "result": [

--- a/tests/filter.json
+++ b/tests/filter.json
@@ -791,6 +791,14 @@
     },
     {
       "name": "equals number, zero and negative zero",
+      "selector" : "$[?@.a==0]",
+      "document" : [{"a": -0, "d": "e"}, {"a":0.1, "d": "f"}, {"a":"0", "d": "g"}],
+      "result": [
+        {"a": -0, "d": "e"}
+      ]
+    },
+    {
+      "name": "equals number, negative zero and zero",
       "selector" : "$[?@.a==-0]",
       "document" : [{"a": 0, "d": "e"}, {"a":0.1, "d": "f"}, {"a":"0", "d": "g"}],
       "result": [
@@ -814,6 +822,14 @@
       ]
     },
     {
+      "name": "equals number, exponent upper e",
+      "selector" : "$[?@.a==1E2]",
+      "document" : [{"a": 100, "d": "e"}, {"a":100.1, "d": "f"}, {"a":"100", "d": "g"}],
+      "result": [
+        {"a": 100, "d": "e"}
+      ]
+    },
+    {
       "name": "equals number, positive exponent",
       "selector" : "$[?@.a==1e+2]",
       "document" : [{"a": 100, "d": "e"}, {"a":100.1, "d": "f"}, {"a":"100", "d": "g"}],
@@ -830,6 +846,22 @@
       ]
     },
     {
+      "name": "equals number, exponent leading 0",
+      "selector" : "$[?@.a==1e-02]",
+      "document" : [{"a": 0.01, "d": "e"}, {"a":0.02, "d": "f"}, {"a":"0.01", "d": "g"}],
+      "result": [
+        {"a": 0.01, "d": "e"}
+      ]
+    },
+    {
+      "name": "equals number, exponent 00",
+      "selector" : "$[?@.a==1e+00]",
+      "document" : [{"a": 1, "d": "e"}, {"a":2, "d": "f"}, {"a":"1", "d": "g"}],
+      "result": [
+        {"a": 1, "d": "e"}
+      ]
+    },
+    {
       "name": "equals number, decimal fraction",
       "selector" : "$[?@.a==1.1]",
       "document" : [{"a": 1.1, "d": "e"}, {"a":1.0, "d": "f"}, {"a":"1.1", "d": "g"}],
@@ -838,9 +870,12 @@
       ]
     },
     {
-      "name": "equals number, decimal fraction, no fractional digit",
-      "selector" : "$[?@.a==1.]",
-      "invalid_selector": true
+      "name": "equals number, decimal fraction, trailing 0",
+      "selector" : "$[?@.a==1.10]",
+      "document" : [{"a": 1.1, "d": "e"}, {"a":1.0, "d": "f"}, {"a":"1.1", "d": "g"}],
+      "result": [
+        {"a": 1.1, "d": "e"}
+      ]
     },
     {
       "name": "equals number, decimal fraction, exponent",
@@ -865,6 +900,91 @@
       "result": [
         {"a": 0.011, "d": "e"}
       ]
+    },
+    {
+      "name": "equals number, invalid plus",
+      "selector" : "$[?@.a==+1]",
+      "invalid_selector": true
+    },
+    {
+      "name": "equals number, invalid minus space",
+      "selector" : "$[?@.a==- 1]",
+      "invalid_selector": true
+    },
+    {
+      "name": "equals number, invalid double minus",
+      "selector" : "$[?@.a==--1]",
+      "invalid_selector": true
+    },
+    {
+      "name": "equals number, invalid no int digit",
+      "selector" : "$[?@.a==.1]",
+      "invalid_selector": true
+    },
+    {
+      "name": "equals number, invalid minus no int digit",
+      "selector" : "$[?@.a==-.1]",
+      "invalid_selector": true
+    },
+    {
+      "name": "equals number, invalid 00",
+      "selector" : "$[?@.a==00]",
+      "invalid_selector": true
+    },
+    {
+      "name": "equals number, invalid leading 0",
+      "selector" : "$[?@.a==01]",
+      "invalid_selector": true
+    },
+    {
+      "name": "equals number, invalid no fractional digit",
+      "selector" : "$[?@.a==1.]",
+      "invalid_selector": true
+    },
+    {
+      "name": "equals number, invalid middle minus",
+      "selector" : "$[?@.a==1.-1]",
+      "invalid_selector": true
+    },
+    {
+      "name": "equals number, invalid no fractional digit e",
+      "selector" : "$[?@.a==1.e1]",
+      "invalid_selector": true
+    },
+    {
+      "name": "equals number, invalid no e digit",
+      "selector" : "$[?@.a==1e]",
+      "invalid_selector": true
+    },
+    {
+      "name": "equals number, invalid no e digit minus",
+      "selector" : "$[?@.a==1e-]",
+      "invalid_selector": true
+    },
+    {
+      "name": "equals number, invalid double e",
+      "selector" : "$[?@.a==1eE1]",
+      "invalid_selector": true
+    },
+    {
+      "name": "equals number, invalid e digit double minus",
+      "selector" : "$[?@.a==1e--1]",
+      "invalid_selector": true
+    },
+    {
+      "name": "equals number, invalid e digit plus minus",
+      "selector" : "$[?@.a==1e+-1]",
+      "invalid_selector": true
+    },
+    {
+      "name": "equals number, invalid e decimal",
+      "selector" : "$[?@.a==1e2.3]",
+      "invalid_selector": true
+    },
+    {
+      "name": "equals number, invalid multi e",
+      "selector" : "$[?@.a==1e2e3]",
+      "invalid_selector": true
     },
     {
       "name": "equals, special nothing",
@@ -1036,6 +1156,21 @@
     {
       "name": "or, left hand literal must be compared",
       "selector" : "$[?false || true == false]",
+      "invalid_selector": true
+    },
+    {
+      "name": "true, incorrectly capitalized",
+      "selector" : "$[?@==True]",
+      "invalid_selector": true
+    },
+    {
+      "name": "false, incorrectly capitalized",
+      "selector" : "$[?@==False]",
+      "invalid_selector": true
+    },
+    {
+      "name": "null, incorrectly capitalized",
+      "selector" : "$[?@==Null]",
       "invalid_selector": true
     }
   ]


### PR DESCRIPTION
Generally for number literals since JSONPath uses the same syntax as JSON, test values from regular JSON libraries or JSON test suites could be used, for example https://github.com/nst/JSONTestSuite.

So if you have anything else in mind which should be covered, please let me know or feel free to add it yourself.