### PR TITLE
Add more tests for selectors

### DIFF
--- a/tests/basic.json
+++ b/tests/basic.json
@@ -171,6 +171,16 @@
       "invalid_selector": true
     },
     {
+      "name": "selector, leading comma",
+      "selector": "$[,0]",
+      "invalid_selector": true
+    },
+    {
+      "name": "selector, trailing comma",
+      "selector": "$[0,]",
+      "invalid_selector": true
+    },
+    {
       "name": "multiple selectors, name and index, array data",
       "selector": "$['a',1]",
       "document": [
@@ -192,6 +202,17 @@
     {
       "name": "multiple selectors, name and index, object data",
       "selector": "$['a',1]",
+      "document": {
+        "a": 1,
+        "b": 2
+      },
+      "result": [
+        1
+      ]
+    },
+    {
+      "name": "multiple selectors, spaces",
+      "selector": "$[ 'a' , 1 ]",
       "document": {
         "a": 1,
         "b": 2

--- a/tests/basic.json
+++ b/tests/basic.json
@@ -211,17 +211,6 @@
       ]
     },
     {
-      "name": "multiple selectors, spaces",
-      "selector": "$[ 'a' , 1 ]",
-      "document": {
-        "a": 1,
-        "b": 2
-      },
-      "result": [
-        1
-      ]
-    },
-    {
       "name": "multiple selectors, index and slice",
       "selector": "$[1,5:7]",
       "document": [

--- a/tests/index_selector.json
+++ b/tests/index_selector.json
@@ -32,6 +32,34 @@
       "result": []
     },
     {
+      "name": "min exact index",
+      "selector": "$[-9007199254740991]",
+      "document": [
+        "first",
+        "second"
+      ],
+      "result": []
+    },
+    {
+      "name": "max exact index",
+      "selector": "$[9007199254740991]",
+      "document": [
+        "first",
+        "second"
+      ],
+      "result": []
+    },
+    {
+      "name": "min exact index - 1",
+      "selector": "$[-9007199254740992]",
+      "invalid_selector": true
+    },
+    {
+      "name": "max exact index + 1",
+      "selector": "$[9007199254740992]",
+      "invalid_selector": true
+    },
+    {
       "name": "overflowing index",
       "selector": "$[231584178474632390847141970017375815706539969331281128078915168015826259279872]",
       "invalid_selector": true
@@ -83,6 +111,26 @@
     {
       "name": "leading 0",
       "selector": "$[01]",
+      "invalid_selector": true
+    },
+    {
+      "name": "decimal",
+      "selector": "$[1.0]",
+      "invalid_selector": true
+    },
+    {
+      "name": "plus",
+      "selector": "$[+1]",
+      "invalid_selector": true
+    },
+    {
+      "name": "minus space",
+      "selector": "$[- 1]",
+      "invalid_selector": true
+    },
+    {
+      "name": "-0",
+      "selector": "$[-0]",
       "invalid_selector": true
     },
     {

--- a/tests/slice_selector.json
+++ b/tests/slice_selector.json
@@ -611,25 +611,69 @@
       ]
     },
     {
-      "name": "min exact",
+      "name": "start, min exact",
+      "selector": "$[-9007199254740991::]",
+      "document": [],
+      "result": []
+    },
+    {
+      "name": "start, max exact",
+      "selector": "$[9007199254740991::]",
+      "document": [],
+      "result": []
+    },
+    {
+      "name": "start, min exact - 1",
+      "selector": "$[-9007199254740992::]",
+      "invalid_selector": true
+    },
+    {
+      "name": "start, max exact + 1",
+      "selector": "$[9007199254740992::]",
+      "invalid_selector": true
+    },
+    {
+      "name": "end, min exact",
       "selector": "$[:-9007199254740991:]",
       "document": [],
       "result": []
     },
     {
-      "name": "max exact",
+      "name": "end, max exact",
       "selector": "$[:9007199254740991:]",
       "document": [],
       "result": []
     },
     {
-      "name": "min exact - 1",
+      "name": "end, min exact - 1",
       "selector": "$[:-9007199254740992:]",
       "invalid_selector": true
     },
     {
-      "name": "max exact + 1",
+      "name": "end, max exact + 1",
       "selector": "$[:9007199254740992:]",
+      "invalid_selector": true
+    },
+    {
+      "name": "step, min exact",
+      "selector": "$[::-9007199254740991]",
+      "document": [],
+      "result": []
+    },
+    {
+      "name": "step, max exact",
+      "selector": "$[::9007199254740991]",
+      "document": [],
+      "result": []
+    },
+    {
+      "name": "step, min exact - 1",
+      "selector": "$[::-9007199254740992]",
+      "invalid_selector": true
+    },
+    {
+      "name": "step, max exact + 1",
+      "selector": "$[::9007199254740992]",
       "invalid_selector": true
     },
     {
@@ -663,33 +707,93 @@
       "invalid_selector": true
     },
     {
-      "name": "leading 0",
+      "name": "start, leading 0",
+      "selector": "$[01::]",
+      "invalid_selector": true
+    },
+    {
+      "name": "start, decimal",
+      "selector": "$[1.0::]",
+      "invalid_selector": true
+    },
+    {
+      "name": "start, plus",
+      "selector": "$[+1::]",
+      "invalid_selector": true
+    },
+    {
+      "name": "start, minus space",
+      "selector": "$[- 1::]",
+      "invalid_selector": true
+    },
+    {
+      "name": "start, -0",
+      "selector": "$[-0::]",
+      "invalid_selector": true
+    },
+    {
+      "name": "start, leading -0",
+      "selector": "$[-01::]",
+      "invalid_selector": true
+    },
+    {
+      "name": "end, leading 0",
       "selector": "$[:01:]",
       "invalid_selector": true
     },
     {
-      "name": "decimal",
+      "name": "end, decimal",
       "selector": "$[:1.0:]",
       "invalid_selector": true
     },
     {
-      "name": "plus",
+      "name": "end, plus",
       "selector": "$[:+1:]",
       "invalid_selector": true
     },
     {
-      "name": "minus space",
+      "name": "end, minus space",
       "selector": "$[:- 1:]",
       "invalid_selector": true
     },
     {
-      "name": "-0",
+      "name": "end, -0",
       "selector": "$[:-0:]",
       "invalid_selector": true
     },
     {
-      "name": "leading -0",
+      "name": "end, leading -0",
       "selector": "$[:-01:]",
+      "invalid_selector": true
+    },
+    {
+      "name": "step, leading 0",
+      "selector": "$[::01]",
+      "invalid_selector": true
+    },
+    {
+      "name": "step, decimal",
+      "selector": "$[::1.0]",
+      "invalid_selector": true
+    },
+    {
+      "name": "step, plus",
+      "selector": "$[::+1]",
+      "invalid_selector": true
+    },
+    {
+      "name": "step, minus space",
+      "selector": "$[::- 1]",
+      "invalid_selector": true
+    },
+    {
+      "name": "step, -0",
+      "selector": "$[::-0]",
+      "invalid_selector": true
+    },
+    {
+      "name": "step, leading -0",
+      "selector": "$[::-01]",
       "invalid_selector": true
     }
   ]

--- a/tests/slice_selector.json
+++ b/tests/slice_selector.json
@@ -42,6 +42,27 @@
       ]
     },
     {
+      "name": "slice selector with spaces",
+      "selector": "$[ 1 : 6 : 2 ]",
+      "document": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      "result": [
+        1,
+        3,
+        5
+      ]
+    },
+    {
       "name": "slice selector with everything omitted, short form",
       "selector": "$[:]",
       "document": [
@@ -611,6 +632,28 @@
       ]
     },
     {
+      "name": "min exact",
+      "selector": "$[:-9007199254740991:]",
+      "document": [],
+      "result": []
+    },
+    {
+      "name": "max exact",
+      "selector": "$[:9007199254740991:]",
+      "document": [],
+      "result": []
+    },
+    {
+      "name": "min exact - 1",
+      "selector": "$[:-9007199254740992:]",
+      "invalid_selector": true
+    },
+    {
+      "name": "max exact + 1",
+      "selector": "$[:9007199254740992:]",
+      "invalid_selector": true
+    },
+    {
       "name": "overflowing to value",
       "selector": "$[2:231584178474632390847141970017375815706539969331281128078915168015826259279872]",
       "invalid_selector": true
@@ -638,6 +681,36 @@
     {
       "name": "underflowing step",
       "selector": "$[-1:-10:-231584178474632390847141970017375815706539969331281128078915168015826259279872]",
+      "invalid_selector": true
+    },
+    {
+      "name": "leading 0",
+      "selector": "$[:01:]",
+      "invalid_selector": true
+    },
+    {
+      "name": "decimal",
+      "selector": "$[:1.0:]",
+      "invalid_selector": true
+    },
+    {
+      "name": "plus",
+      "selector": "$[:+1:]",
+      "invalid_selector": true
+    },
+    {
+      "name": "minus space",
+      "selector": "$[:- 1:]",
+      "invalid_selector": true
+    },
+    {
+      "name": "-0",
+      "selector": "$[:-0:]",
+      "invalid_selector": true
+    },
+    {
+      "name": "leading -0",
+      "selector": "$[:-01:]",
       "invalid_selector": true
     }
   ]

--- a/tests/slice_selector.json
+++ b/tests/slice_selector.json
@@ -42,27 +42,6 @@
       ]
     },
     {
-      "name": "slice selector with spaces",
-      "selector": "$[ 1 : 6 : 2 ]",
-      "document": [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9
-      ],
-      "result": [
-        1,
-        3,
-        5
-      ]
-    },
-    {
       "name": "slice selector with everything omitted, short form",
       "selector": "$[:]",
       "document": [


### PR DESCRIPTION
The "min exact" and "max exact" values here are based on the "range of exact integer values defined in Internet JSON (I-JSON)", as required by the JSONPath specification for index and slice selectors.
I have kept the existing overflow tests because they might still be useful to test overflow during parsing, which might happen before the "range of exact integer values" check in JSONPath implementations.

To be safe, could you please check how your JSONPath implementations behave, to make sure I did not overlook something.