### PR TITLE
Check for duplicate test names

### DIFF
--- a/tests/whitespace/selectors.json
+++ b/tests/whitespace/selectors.json
@@ -36,21 +36,21 @@
       "tags": ["whitespace"]
     },
     {
-      "name": "newline between root and bracket",
+      "name": "newline between bracket and bracket",
       "selector" : "$['a'] \n['b']",
       "document" : {"a": {"b": "ab"} },
       "result": [ "ab" ],
       "tags": ["whitespace"]
     },
     {
-      "name": "tab between root and bracket",
+      "name": "tab between bracket and bracket",
       "selector" : "$['a'] \t['b']",
       "document" : {"a": {"b": "ab"} },
       "result": [ "ab" ],
       "tags": ["whitespace"]
     },
     {
-      "name": "return between root and bracket",
+      "name": "return between bracket and bracket",
       "selector" : "$['a'] \r['b']",
       "document" : {"a": {"b": "ab"} },
       "result": [ "ab" ],


### PR DESCRIPTION
Inspired by https://github.com/jsonpath-standard/jsonpath-compliance-test-suite/issues/36#issuecomment-1523515817

Due to copy & paste errors there were already duplicate names in `selectors.json`, see changes below.

Not sure if the change in `build.js` clean enough, please let me know if I should change it in some way.