### PR TITLE
Add missing function tags

### DIFF
--- a/tests/filter.json
+++ b/tests/filter.json
@@ -1073,7 +1073,8 @@
       "result": [
         {"c": "d"},
         {"a": null}
-      ]
+      ],
+      "tags": ["function"]
     },
     {
       "name": "equals, empty node list and empty node list",
@@ -1091,7 +1092,7 @@
         {"b": 2},
         {"c": 3}
       ],
-      "tags": ["whitespace"]
+      "tags": ["whitespace", "function"]
     },
     {
       "name": "object data",


### PR DESCRIPTION
With my current implementation, I am skipping function tests based on tags. A couple tests were missing the `function` tag. Hence added in this PR. This would also help me in submoduling the repository instead of testing on a locally patched `cts.json`.