### PR TITLE
Additional filter and array slice selector tests

### DIFF
--- a/tests/basic.json
+++ b/tests/basic.json
@@ -920,6 +920,16 @@
       "name": "bald descendant segment",
       "selector": "$..",
       "invalid_selector": true
+    },
+    {
+      "name": "current node identifier without filter selector",
+      "selector": "$[@.a]",
+      "invalid_selector": true
+    },
+    {
+      "name": "root node identifier in brackets without filter selector",
+      "selector": "$[$.a]",
+      "invalid_selector": true
     }
   ]
 }

--- a/tests/filter.json
+++ b/tests/filter.json
@@ -404,6 +404,21 @@
       ]
     },
     {
+      "name": "equals, absent from index selector equals absent from name selector",
+      "selector": "$[?@.absent==@.list[9]]",
+      "document": [
+        {
+          "list": [1]
+        }
+      ],
+      "result": [
+        { "list": [1] }
+      ],
+      "result_paths": [
+        "$[0]"
+      ]
+    },
+    {
       "name": "deep equality, arrays",
       "selector": "$[?@.a==@.b]",
       "document": [

--- a/tests/slice_selector.json
+++ b/tests/slice_selector.json
@@ -573,6 +573,35 @@
       ]
     },
     {
+      "name": "negative from, negative to, positive step",
+      "selector": "$[-5:-2]",
+      "document": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      "result": [
+        5,
+        6,
+        7
+      ],
+      "result_paths": [
+        "$[5]",
+        "$[6]",
+        "$[7]"
+      ],
+      "tags": [
+        "slice"
+      ]
+    },
+    {
       "name": "too many colons",
       "selector": "$[1:2:3:4]",
       "invalid_selector": true,


### PR DESCRIPTION
A few more tests:

* filter selector,  non-matching name and index selectors are equal within a comparison
* array slice selector, test negative start and end indexes with positive step
* invalid selector tests for using @ and $ outside of filter expression

There is already an array slice selector test `$[-1:-3]` with negative start and end, but that one returns no results because the default step doesn't go in the right direction (ie. from start index to end index.)
The point of this new test is that it is a negative start/end query that actually returns values.