### PR TITLE
Add ValueType function-argument singular query tests

### DIFF
--- a/cts.json
+++ b/cts.json
@@ -7578,7 +7578,7 @@
       ]
     },
     {
-      "name": "functions, length, functions, length, non-singular query arg, multiple index selectors",
+      "name": "functions, length, non-singular query arg, multiple index selectors",
       "selector": "$[?length(@[1, 2])<3]",
       "invalid_selector": true,
       "tags": [
@@ -7587,7 +7587,7 @@
       ]
     },
     {
-      "name": "functions, length, functions, length, non-singular query arg, multiple name selectors",
+      "name": "functions, length, non-singular query arg, multiple name selectors",
       "selector": "$[?length(@['a', 'b'])<3]",
       "invalid_selector": true,
       "tags": [

--- a/cts.json
+++ b/cts.json
@@ -7578,6 +7578,24 @@
       ]
     },
     {
+      "name": "functions, length, functions, length, non-singular query arg, multiple index selectors",
+      "selector": "$[?length(@[1, 2])<3]",
+      "invalid_selector": true,
+      "tags": [
+        "function",
+        "length"
+      ]
+    },
+    {
+      "name": "functions, length, functions, length, non-singular query arg, multiple name selectors",
+      "selector": "$[?length(@['a', 'b'])<3]",
+      "invalid_selector": true,
+      "tags": [
+        "function",
+        "length"
+      ]
+    },
+    {
       "name": "functions, match, found match",
       "selector": "$[?match(@.a, 'a.*')]",
       "document": [

--- a/tests/functions/length.json
+++ b/tests/functions/length.json
@@ -253,7 +253,7 @@
       ]
     },
     {
-      "name": "functions, length, non-singular query arg, multiple index selectors",
+      "name": "non-singular query arg, multiple index selectors",
       "selector": "$[?length(@[1, 2])<3]",
       "invalid_selector": true,
       "tags": [
@@ -262,7 +262,7 @@
       ]
     },
     {
-      "name": "functions, length, non-singular query arg, multiple name selectors",
+      "name": "non-singular query arg, multiple name selectors",
       "selector": "$[?length(@['a', 'b'])<3]",
       "invalid_selector": true,
       "tags": [

--- a/tests/functions/length.json
+++ b/tests/functions/length.json
@@ -251,6 +251,24 @@
         "function",
         "length"
       ]
+    },
+    {
+      "name": "functions, length, non-singular query arg, multiple index selectors",
+      "selector": "$[?length(@[1, 2])<3]",
+      "invalid_selector": true,
+      "tags": [
+        "function",
+        "length"
+      ]
+    },
+    {
+      "name": "functions, length, non-singular query arg, multiple name selectors",
+      "selector": "$[?length(@['a', 'b'])<3]",
+      "invalid_selector": true,
+      "tags": [
+        "function",
+        "length"
+      ]
     }
   ]
 }


### PR DESCRIPTION
There is a test for ValueType function-arguments that reference a non-singulary query with wildcard.
But no such test for index-selectors with multiple indices nor for name-selectors with multiple names.
Adding one test of each type which will show an error in the query.