### PR TITLE
Test JSON bool, null literal shorthand names

### DIFF
--- a/tests/basic.json
+++ b/tests/basic.json
@@ -565,6 +565,57 @@
       ]
     },
     {
+      "name": "name shorthand, true",
+      "selector": "$.true",
+      "document": {
+        "true": "A",
+        "_foo": "B"
+      },
+      "result": [
+        "A"
+      ],
+      "result_paths": [
+        "$['true']"
+      ],
+      "tags": [
+        "boundary"
+      ]
+    },
+    {
+      "name": "name shorthand, false",
+      "selector": "$.false",
+      "document": {
+        "false": "A",
+        "_foo": "B"
+      },
+      "result": [
+        "A"
+      ],
+      "result_paths": [
+        "$['false']"
+      ],
+      "tags": [
+        "boundary"
+      ]
+    },
+    {
+      "name": "name shorthand, null",
+      "selector": "$.null",
+      "document": {
+        "null": "A",
+        "_foo": "B"
+      },
+      "result": [
+        "A"
+      ],
+      "result_paths": [
+        "$['null']"
+      ],
+      "tags": [
+        "boundary"
+      ]
+    },
+    {
       "name": "descendant segment, wildcard shorthand, array data",
       "selector": "$..*",
       "document": [


### PR DESCRIPTION
Section 2.5.1.1 defines shorthand names with this grammar:

```anbf
member-name-shorthand = name-first *name-char
name-first          = ALPHA /
                      "_"   /
                      %x80-D7FF /
                         ; skip surrogate code points
                      %xE000-10FFFF
name-char           = name-first / DIGIT
```

This allows shorthand names that correspond to the JSON literals `true`, `false`, and `null`.

So add tests for this pattern.